### PR TITLE
feat: Add manual transcript file upload support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,12 @@ The backend now has a proper service layer with clear separation:
 # Process a YouTube video
 python scripts/cli.py process-video 'https://www.youtube.com/watch?v=VIDEO_ID'
 
+# Process a transcript file (when YouTube API is blocked)
+python scripts/cli.py process-transcript path/to/transcript.txt
+
+# Process multiple transcript files from a folder
+python scripts/cli.py process-transcripts path/to/transcripts/ --recursive
+
 # List restaurants with filters
 python scripts/cli.py list-restaurants --location "תל אביב" --cuisine "Italian"
 
@@ -83,10 +89,17 @@ python scripts/cli.py health
 python scripts/cli.py analytics trends --period 3months
 ```
 
+**Supported Transcript Formats:**
+- `.txt` - Plain text transcript
+- `.json` - JSON with 'transcript' or 'segments' field
+- `.srt` - SubRip subtitle format
+- `.vtt` - WebVTT subtitle format
+
 ### Core Python Modules (src/)
 
 - `database.py` - SQLite database with episodes, restaurants, and jobs tables
 - `backend_service.py` - Unified service layer for all backend operations
+- `transcript_file_loader.py` - Loads transcript files from disk (txt, json, srt, vtt)
 - `youtube_transcript_collector.py` - Fetches YouTube transcripts using youtube-transcript-api
 - `youtube_channel_collector.py` - Processes entire YouTube channels
 - `claude_restaurant_analyzer.py` / `openai_restaurant_analyzer.py` - AI-based restaurant extraction from transcripts

--- a/src/transcript_file_loader.py
+++ b/src/transcript_file_loader.py
@@ -1,0 +1,414 @@
+"""
+Transcript File Loader for Where2Eat.
+
+Loads transcript files from disk in various formats:
+- .txt - Plain text transcripts
+- .json - JSON format (YouTube API format or custom)
+- .srt - SubRip subtitle format
+- .vtt - WebVTT subtitle format
+
+This allows manual upload of transcripts when the YouTube API
+rate limits or blocks automatic fetching.
+"""
+
+import os
+import re
+import json
+from typing import Dict, List, Optional, Any
+
+
+class TranscriptFileLoader:
+    """
+    Load transcript files from disk in various formats.
+
+    Supported formats:
+    - .txt: Plain text (full transcript as single block)
+    - .json: JSON with 'transcript' field or 'segments' array
+    - .srt: SubRip subtitle format
+    - .vtt: WebVTT subtitle format
+    """
+
+    SUPPORTED_FORMATS = ['.txt', '.json', '.srt', '.vtt']
+
+    def __init__(self):
+        """Initialize the transcript file loader."""
+        pass
+
+    def load_file(
+        self,
+        file_path: str,
+        video_id: Optional[str] = None,
+        language: str = 'he',
+        title: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Load a transcript file and return standardized transcript data.
+
+        Args:
+            file_path: Path to the transcript file
+            video_id: Optional video ID (extracted from filename if not provided)
+            language: Language code (default: 'he')
+            title: Optional episode title
+
+        Returns:
+            Dict with keys:
+                - success: bool
+                - transcript: str (full text)
+                - segments: List[Dict] (timestamped segments if available)
+                - video_id: str
+                - language: str
+                - title: str (optional)
+                - source_file: str
+                - error: str (if success is False)
+        """
+        # Check if file exists
+        if not os.path.exists(file_path):
+            return {
+                'success': False,
+                'error': f'File not found: {file_path}',
+                'source_file': file_path
+            }
+
+        # Check file extension
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext not in self.SUPPORTED_FORMATS:
+            return {
+                'success': False,
+                'error': f'Unsupported file format: {ext}. Supported: {", ".join(self.SUPPORTED_FORMATS)}',
+                'source_file': file_path
+            }
+
+        # Generate video_id from filename if not provided
+        if not video_id:
+            video_id = self._extract_video_id_from_filename(os.path.basename(file_path))
+
+        # Load based on format
+        try:
+            if ext == '.txt':
+                result = self._load_txt_file(file_path)
+            elif ext == '.json':
+                result = self._load_json_file(file_path)
+            elif ext == '.srt':
+                result = self._load_srt_file(file_path)
+            elif ext == '.vtt':
+                result = self._load_vtt_file(file_path)
+            else:
+                return {
+                    'success': False,
+                    'error': f'Unsupported format: {ext}',
+                    'source_file': file_path
+                }
+
+            # Check for empty content
+            if not result.get('transcript', '').strip():
+                return {
+                    'success': False,
+                    'error': 'Empty transcript file',
+                    'source_file': file_path
+                }
+
+            # Merge with metadata (preserve values from file if present)
+            result['success'] = True
+            if 'video_id' not in result or not result['video_id']:
+                result['video_id'] = video_id
+            if 'language' not in result or not result['language']:
+                result['language'] = language
+            result['source_file'] = file_path
+
+            if title:
+                result['title'] = title
+
+            return result
+
+        except json.JSONDecodeError as e:
+            return {
+                'success': False,
+                'error': f'Invalid JSON: {str(e)}',
+                'source_file': file_path
+            }
+        except Exception as e:
+            return {
+                'success': False,
+                'error': f'Error loading file: {str(e)}',
+                'source_file': file_path
+            }
+
+    def load_folder(
+        self,
+        folder_path: str,
+        recursive: bool = False,
+        language: str = 'he'
+    ) -> List[Dict[str, Any]]:
+        """
+        Load all transcript files from a folder.
+
+        Args:
+            folder_path: Path to folder containing transcript files
+            recursive: Whether to search subdirectories
+            language: Default language for all files
+
+        Returns:
+            List of transcript data dicts (same format as load_file)
+
+        Raises:
+            FileNotFoundError: If folder doesn't exist
+        """
+        if not os.path.exists(folder_path):
+            raise FileNotFoundError(f'Folder not found: {folder_path}')
+
+        if not os.path.isdir(folder_path):
+            raise FileNotFoundError(f'Not a directory: {folder_path}')
+
+        results = []
+
+        if recursive:
+            for root, dirs, files in os.walk(folder_path):
+                for filename in files:
+                    if self._is_supported_file(filename):
+                        file_path = os.path.join(root, filename)
+                        result = self.load_file(file_path, language=language)
+                        if result['success']:
+                            results.append(result)
+        else:
+            for filename in os.listdir(folder_path):
+                if self._is_supported_file(filename):
+                    file_path = os.path.join(folder_path, filename)
+                    if os.path.isfile(file_path):
+                        result = self.load_file(file_path, language=language)
+                        if result['success']:
+                            results.append(result)
+
+        return results
+
+    def _is_supported_file(self, filename: str) -> bool:
+        """Check if a filename has a supported extension."""
+        ext = os.path.splitext(filename)[1].lower()
+        return ext in self.SUPPORTED_FORMATS
+
+    def _load_txt_file(self, file_path: str) -> Dict[str, Any]:
+        """Load plain text transcript file."""
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        return {
+            'transcript': content,
+            'segments': []
+        }
+
+    def _load_json_file(self, file_path: str) -> Dict[str, Any]:
+        """Load JSON format transcript file."""
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        # Handle array format (YouTube API style)
+        if isinstance(data, list):
+            segments = data
+            transcript = ' '.join(seg.get('text', '') for seg in segments)
+            return {
+                'transcript': transcript,
+                'segments': segments
+            }
+
+        # Handle object format
+        if isinstance(data, dict):
+            result = {}
+
+            # Check for segments array
+            if 'segments' in data:
+                segments = data['segments']
+                transcript = ' '.join(seg.get('text', '') for seg in segments)
+                result['segments'] = segments
+                result['transcript'] = data.get('transcript', transcript)
+            elif 'transcript' in data:
+                result['transcript'] = data['transcript']
+                result['segments'] = []
+            else:
+                # Try to use any 'text' field
+                result['transcript'] = data.get('text', '')
+                result['segments'] = []
+
+            # Preserve other metadata from JSON
+            for key in ['video_id', 'language', 'title', 'video_url']:
+                if key in data:
+                    result[key] = data[key]
+
+            return result
+
+        return {
+            'transcript': str(data),
+            'segments': []
+        }
+
+    def _load_srt_file(self, file_path: str) -> Dict[str, Any]:
+        """Load SRT subtitle file."""
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        segments = []
+        transcript_parts = []
+
+        # SRT format:
+        # 1
+        # 00:00:00,000 --> 00:00:03,000
+        # Text line 1
+        # Text line 2
+        #
+        # 2
+        # ...
+
+        blocks = re.split(r'\n\s*\n', content.strip())
+
+        for block in blocks:
+            lines = block.strip().split('\n')
+            if len(lines) >= 3:
+                # First line is sequence number
+                # Second line is timestamp
+                # Rest is text
+                timestamp_line = lines[1]
+                text_lines = lines[2:]
+
+                # Parse timestamps
+                match = re.match(
+                    r'(\d{2}:\d{2}:\d{2}[,\.]\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}[,\.]\d{3})',
+                    timestamp_line
+                )
+
+                if match:
+                    start_time = self._parse_timestamp(match.group(1))
+                    end_time = self._parse_timestamp(match.group(2))
+                    text = ' '.join(text_lines)
+
+                    segments.append({
+                        'text': text,
+                        'start': start_time,
+                        'duration': end_time - start_time
+                    })
+                    transcript_parts.append(text)
+
+        return {
+            'transcript': ' '.join(transcript_parts),
+            'segments': segments
+        }
+
+    def _load_vtt_file(self, file_path: str) -> Dict[str, Any]:
+        """Load WebVTT subtitle file."""
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        segments = []
+        transcript_parts = []
+
+        # Remove WEBVTT header and any metadata
+        lines = content.split('\n')
+        start_idx = 0
+        for i, line in enumerate(lines):
+            if line.strip() == 'WEBVTT' or line.startswith('NOTE') or line.startswith('STYLE'):
+                start_idx = i + 1
+                continue
+            if line.strip() and '-->' in line:
+                start_idx = i
+                break
+            if line.strip() and not line.startswith('WEBVTT'):
+                break
+
+        content = '\n'.join(lines[start_idx:])
+        blocks = re.split(r'\n\s*\n', content.strip())
+
+        for block in blocks:
+            lines = block.strip().split('\n')
+            if not lines:
+                continue
+
+            # Find timestamp line
+            timestamp_line = None
+            text_start = 0
+
+            for i, line in enumerate(lines):
+                if '-->' in line:
+                    timestamp_line = line
+                    text_start = i + 1
+                    break
+
+            if timestamp_line and text_start < len(lines):
+                text_lines = lines[text_start:]
+
+                # Parse timestamps
+                match = re.match(
+                    r'(\d{2}:\d{2}:\d{2}[.,]\d{3}|\d{2}:\d{2}[.,]\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}[.,]\d{3}|\d{2}:\d{2}[.,]\d{3})',
+                    timestamp_line
+                )
+
+                if match:
+                    start_time = self._parse_timestamp(match.group(1))
+                    end_time = self._parse_timestamp(match.group(2))
+                    text = ' '.join(line for line in text_lines if line.strip())
+
+                    # Remove VTT formatting tags
+                    text = re.sub(r'<[^>]+>', '', text)
+
+                    if text.strip():
+                        segments.append({
+                            'text': text,
+                            'start': start_time,
+                            'duration': end_time - start_time
+                        })
+                        transcript_parts.append(text)
+
+        return {
+            'transcript': ' '.join(transcript_parts),
+            'segments': segments
+        }
+
+    def _parse_timestamp(self, timestamp: str) -> float:
+        """
+        Parse SRT/VTT timestamp to seconds.
+
+        Formats:
+        - SRT: 00:01:30,500
+        - VTT: 00:01:30.500 or 01:30.500
+        """
+        # Normalize separator
+        timestamp = timestamp.replace(',', '.')
+
+        parts = timestamp.split(':')
+
+        if len(parts) == 3:
+            hours, minutes, seconds = parts
+            return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+        elif len(parts) == 2:
+            minutes, seconds = parts
+            return int(minutes) * 60 + float(seconds)
+        else:
+            return float(timestamp)
+
+    def _extract_video_id_from_filename(self, filename: str) -> str:
+        """
+        Extract video ID from filename.
+
+        Handles patterns like:
+        - 6jvskRWvQkg.txt
+        - transcript_6jvskRWvQkg.json
+        - 6jvskRWvQkg_hebrew.srt
+        - episode_one.txt
+        """
+        # Remove extension
+        name = os.path.splitext(filename)[0]
+
+        # Try to find YouTube video ID pattern (11 alphanumeric + _ + -)
+        youtube_pattern = r'([a-zA-Z0-9_-]{11})'
+        matches = re.findall(youtube_pattern, name)
+
+        if matches:
+            # Return the first 11-character match that looks like a YouTube ID
+            for match in matches:
+                # Verify it has mixed case/numbers (typical of YouTube IDs)
+                if any(c.isdigit() for c in match) or any(c.isupper() for c in match):
+                    return match
+
+        # Fall back to cleaned filename
+        # Replace spaces and special chars with underscore
+        clean_name = re.sub(r'[^a-zA-Z0-9_-]', '_', name)
+        clean_name = re.sub(r'_+', '_', clean_name)
+        clean_name = clean_name.strip('_')
+
+        return clean_name if clean_name else 'unknown'

--- a/tests/test_transcript_file_loader.py
+++ b/tests/test_transcript_file_loader.py
@@ -1,0 +1,474 @@
+"""
+Tests for TranscriptFileLoader.
+TDD: Tests written first - implementation follows.
+"""
+
+import os
+import sys
+import json
+import pytest
+import tempfile
+
+# Add project paths
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+
+class TestTranscriptFileLoaderInit:
+    """Test TranscriptFileLoader initialization."""
+
+    def test_loader_can_be_instantiated(self):
+        """Test that loader can be created."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+        assert loader is not None
+
+    def test_loader_has_supported_formats(self):
+        """Test that loader defines supported formats."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+        assert hasattr(loader, 'SUPPORTED_FORMATS')
+        assert '.txt' in loader.SUPPORTED_FORMATS
+        assert '.json' in loader.SUPPORTED_FORMATS
+        assert '.srt' in loader.SUPPORTED_FORMATS
+        assert '.vtt' in loader.SUPPORTED_FORMATS
+
+
+class TestLoadTxtFile:
+    """Test loading plain text transcript files."""
+
+    def test_load_txt_file_returns_transcript_data(self):
+        """Test loading a simple text file."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write("שלום, היום נדבר על מסעדה צ'קולי בתל אביב.\n")
+            f.write("זה מקום ספרדי עם אוכל נהדר.")
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(temp_path)
+
+            assert result['success'] is True
+            assert 'transcript' in result
+            assert "צ'קולי" in result['transcript']
+            assert 'source_file' in result
+            assert result['source_file'] == temp_path
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_txt_file_with_custom_metadata(self):
+        """Test loading text file with metadata override."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write("Test transcript content")
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(
+                temp_path,
+                video_id='custom123',
+                language='en',
+                title='Custom Title'
+            )
+
+            assert result['success'] is True
+            assert result['video_id'] == 'custom123'
+            assert result['language'] == 'en'
+            assert result['title'] == 'Custom Title'
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_txt_file_generates_video_id_from_filename(self):
+        """Test that video_id is generated from filename if not provided."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = os.path.join(temp_dir, 'episode_abc123.txt')
+            with open(file_path, 'w') as f:
+                f.write("Test content")
+
+            result = loader.load_file(file_path)
+
+            assert result['success'] is True
+            assert result['video_id'] == 'episode_abc123'
+
+
+class TestLoadJsonFile:
+    """Test loading JSON transcript files."""
+
+    def test_load_json_file_with_transcript_field(self):
+        """Test loading JSON with transcript field."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({
+                'transcript': 'מסעדה בתל אביב',
+                'video_id': 'vid123',
+                'language': 'he'
+            }, f, ensure_ascii=False)
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(temp_path)
+
+            assert result['success'] is True
+            assert result['transcript'] == 'מסעדה בתל אביב'
+            assert result['video_id'] == 'vid123'
+            assert result['language'] == 'he'
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_json_file_with_segments(self):
+        """Test loading JSON with segments array."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({
+                'segments': [
+                    {'text': 'First segment', 'start': 0.0, 'duration': 3.0},
+                    {'text': 'Second segment', 'start': 3.0, 'duration': 3.0}
+                ],
+                'video_id': 'seg123'
+            }, f, ensure_ascii=False)
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(temp_path)
+
+            assert result['success'] is True
+            assert 'First segment' in result['transcript']
+            assert 'Second segment' in result['transcript']
+            assert len(result['segments']) == 2
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_json_file_with_text_array(self):
+        """Test loading JSON with text array (YouTube format)."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump([
+                {'text': 'Line one', 'start': 0.0, 'duration': 2.0},
+                {'text': 'Line two', 'start': 2.0, 'duration': 2.0}
+            ], f, ensure_ascii=False)
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(temp_path)
+
+            assert result['success'] is True
+            assert 'Line one' in result['transcript']
+            assert 'Line two' in result['transcript']
+        finally:
+            os.unlink(temp_path)
+
+
+class TestLoadSrtFile:
+    """Test loading SRT subtitle files."""
+
+    def test_load_srt_file(self):
+        """Test loading SRT format file."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        srt_content = """1
+00:00:00,000 --> 00:00:03,000
+שלום וברוכים הבאים
+
+2
+00:00:03,000 --> 00:00:06,500
+היום נדבר על מסעדה צ'קולי
+
+3
+00:00:06,500 --> 00:00:10,000
+בתל אביב
+"""
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.srt', delete=False, encoding='utf-8') as f:
+            f.write(srt_content)
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(temp_path)
+
+            assert result['success'] is True
+            assert 'שלום' in result['transcript']
+            assert "צ'קולי" in result['transcript']
+            assert len(result['segments']) == 3
+            # Check first segment timing
+            assert result['segments'][0]['start'] == 0.0
+            assert result['segments'][0]['duration'] == 3.0
+        finally:
+            os.unlink(temp_path)
+
+
+class TestLoadVttFile:
+    """Test loading WebVTT subtitle files."""
+
+    def test_load_vtt_file(self):
+        """Test loading VTT format file."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        vtt_content = """WEBVTT
+
+00:00:00.000 --> 00:00:03.000
+שלום וברוכים הבאים
+
+00:00:03.000 --> 00:00:06.500
+היום נדבר על מסעדה
+
+00:00:06.500 --> 00:00:10.000
+בירושלים
+"""
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.vtt', delete=False, encoding='utf-8') as f:
+            f.write(vtt_content)
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(temp_path)
+
+            assert result['success'] is True
+            assert 'שלום' in result['transcript']
+            assert 'ירושלים' in result['transcript']
+            assert len(result['segments']) == 3
+        finally:
+            os.unlink(temp_path)
+
+
+class TestLoadFolder:
+    """Test loading multiple transcript files from a folder."""
+
+    def test_load_folder_returns_list_of_transcripts(self):
+        """Test loading all transcripts from a folder."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create multiple transcript files
+            with open(os.path.join(temp_dir, 'ep1.txt'), 'w') as f:
+                f.write("Episode 1 content")
+
+            with open(os.path.join(temp_dir, 'ep2.txt'), 'w') as f:
+                f.write("Episode 2 content")
+
+            with open(os.path.join(temp_dir, 'ep3.json'), 'w') as f:
+                json.dump({'transcript': 'Episode 3 content'}, f)
+
+            results = loader.load_folder(temp_dir)
+
+            assert len(results) == 3
+            assert all(r['success'] for r in results)
+
+    def test_load_folder_skips_unsupported_files(self):
+        """Test that unsupported file types are skipped."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with open(os.path.join(temp_dir, 'valid.txt'), 'w') as f:
+                f.write("Valid content")
+
+            with open(os.path.join(temp_dir, 'image.png'), 'w') as f:
+                f.write("Not a transcript")
+
+            with open(os.path.join(temp_dir, 'readme.md'), 'w') as f:
+                f.write("Also not a transcript")
+
+            results = loader.load_folder(temp_dir)
+
+            assert len(results) == 1
+            assert results[0]['video_id'] == 'valid'
+
+    def test_load_folder_handles_recursive_option(self):
+        """Test recursive folder loading."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create nested structure
+            subdir = os.path.join(temp_dir, 'subdir')
+            os.makedirs(subdir)
+
+            with open(os.path.join(temp_dir, 'root.txt'), 'w') as f:
+                f.write("Root content")
+
+            with open(os.path.join(subdir, 'nested.txt'), 'w') as f:
+                f.write("Nested content")
+
+            # Non-recursive
+            results = loader.load_folder(temp_dir, recursive=False)
+            assert len(results) == 1
+
+            # Recursive
+            results = loader.load_folder(temp_dir, recursive=True)
+            assert len(results) == 2
+
+    def test_load_folder_returns_empty_for_empty_folder(self):
+        """Test loading from empty folder."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            results = loader.load_folder(temp_dir)
+            assert results == []
+
+    def test_load_folder_handles_nonexistent_path(self):
+        """Test error handling for non-existent folder."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with pytest.raises(FileNotFoundError):
+            loader.load_folder('/nonexistent/path')
+
+
+class TestErrorHandling:
+    """Test error handling in file loading."""
+
+    def test_load_nonexistent_file(self):
+        """Test loading non-existent file returns error."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        result = loader.load_file('/nonexistent/file.txt')
+
+        assert result['success'] is False
+        assert 'error' in result
+
+    def test_load_unsupported_format(self):
+        """Test loading unsupported file format."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xyz', delete=False) as f:
+            f.write("Some content")
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(temp_path)
+
+            assert result['success'] is False
+            assert 'unsupported' in result['error'].lower()
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_malformed_json(self):
+        """Test loading malformed JSON file."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write("{invalid json content")
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(temp_path)
+
+            assert result['success'] is False
+            assert 'error' in result
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_empty_file(self):
+        """Test loading empty file."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            temp_path = f.name
+
+        try:
+            result = loader.load_file(temp_path)
+
+            assert result['success'] is False
+            assert 'empty' in result['error'].lower()
+        finally:
+            os.unlink(temp_path)
+
+
+class TestTimestampParsing:
+    """Test timestamp parsing for SRT/VTT formats."""
+
+    def test_parse_srt_timestamp(self):
+        """Test parsing SRT timestamp format."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        # SRT format: 00:01:30,500
+        seconds = loader._parse_timestamp('00:01:30,500')
+        assert seconds == 90.5
+
+    def test_parse_vtt_timestamp(self):
+        """Test parsing VTT timestamp format."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        # VTT format: 00:01:30.500
+        seconds = loader._parse_timestamp('00:01:30.500')
+        assert seconds == 90.5
+
+    def test_parse_short_timestamp(self):
+        """Test parsing short timestamp format (MM:SS)."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        seconds = loader._parse_timestamp('01:30.500')
+        assert seconds == 90.5
+
+
+class TestMetadataExtraction:
+    """Test metadata extraction from filenames."""
+
+    def test_extract_video_id_from_youtube_format(self):
+        """Test extracting video ID from YouTube-style filename."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        # Common YouTube transcript filename patterns
+        assert loader._extract_video_id_from_filename('6jvskRWvQkg.txt') == '6jvskRWvQkg'
+        assert loader._extract_video_id_from_filename('transcript_6jvskRWvQkg.json') == '6jvskRWvQkg'
+        assert loader._extract_video_id_from_filename('6jvskRWvQkg_hebrew.srt') == '6jvskRWvQkg'
+
+    def test_extract_video_id_from_generic_filename(self):
+        """Test video ID from generic filename."""
+        from transcript_file_loader import TranscriptFileLoader
+
+        loader = TranscriptFileLoader()
+
+        assert loader._extract_video_id_from_filename('episode_one.txt') == 'episode_one'
+        assert loader._extract_video_id_from_filename('my podcast.txt') == 'my_podcast'
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
Add ability to process transcript files directly when YouTube API
rate limiting blocks automatic transcript fetching.

New features:
- TranscriptFileLoader: Load transcripts from .txt, .json, .srt, .vtt
- BackendService.process_transcript_file(): Process single file
- BackendService.process_transcript_folder(): Batch process folder
- CLI commands: process-transcript and process-transcripts

Includes 31 new tests with 94% coverage on new code.