### PR TITLE
fix: Replace hardcoded Hebrew text with translation calls

### DIFF
--- a/web/src/components/animated-filters.tsx
+++ b/web/src/components/animated-filters.tsx
@@ -9,6 +9,7 @@ import { LocationFilter } from "./location-filter"
 import { CuisineFilter } from "./cuisine-filter"
 import { PriceFilter } from "./price-filter"
 import { Restaurant } from "@/types/restaurant"
+import { useLanguage } from "@/contexts/LanguageContext"
 
 interface AnimatedFiltersProps {
   restaurants: Restaurant[]
@@ -29,6 +30,7 @@ export function AnimatedFilters({
   onFiltersChange,
   onClear
 }: AnimatedFiltersProps) {
+  const { t } = useLanguage()
   const [isOpen, setIsOpen] = useState(false)
 
   const containerVariants = {
@@ -80,12 +82,12 @@ export function AnimatedFilters({
           >
             {isOpen ? <X className="size-5" /> : <Filter className="size-5" />}
             <CardTitle className="text-orange-600">
-              מסננים {!isOpen && '(לחץ להרחבה)'}
+              {t('common.filters')} {!isOpen && t('filters.location.filterExpandHint')}
             </CardTitle>
           </Button>
           {isOpen && (
             <Button variant="outline" onClick={onClear} size="sm">
-              נקה מסננים
+              {t('common.clearFilters')}
             </Button>
           )}
         </div>

--- a/web/src/components/bento-hero.tsx
+++ b/web/src/components/bento-hero.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge"
 import { TrendingUp, MapPin, Star, Users } from "lucide-react"
 import { Restaurant } from "@/types/restaurant"
 import { OptimizedImage } from "./optimized-image"
+import { useLanguage } from "@/contexts/LanguageContext"
 
 interface BentoHeroProps {
   featuredRestaurants: Restaurant[]
@@ -17,6 +18,7 @@ interface BentoHeroProps {
 }
 
 export function BentoHero({ featuredRestaurants, stats }: BentoHeroProps) {
+  const { t } = useLanguage()
   const featured = featuredRestaurants.slice(0, 3)
 
   return (
@@ -34,7 +36,7 @@ export function BentoHero({ featuredRestaurants, stats }: BentoHeroProps) {
             />
             <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
             <div className="absolute bottom-0 left-0 right-0 p-6 text-white">
-              <Badge className="bg-orange-500 text-white mb-3">מומלץ ביותר</Badge>
+              <Badge className="bg-orange-500 text-white mb-3">{t('restaurant.highlyRecommended')}</Badge>
               <h2 className="image-headline text-white mb-2">
                 {featured[0].name_hebrew}
               </h2>
@@ -63,24 +65,24 @@ export function BentoHero({ featuredRestaurants, stats }: BentoHeroProps) {
         <div className="p-6">
           <div className="flex items-center gap-2 mb-4">
             <TrendingUp className="size-5" />
-            <h3 className="text-lg font-bold">סטטיסטיקות מערכת</h3>
+            <h3 className="text-lg font-bold">{t('stats.systemStats')}</h3>
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
               <div className="text-3xl font-bold">{stats.totalRestaurants}</div>
-              <div className="text-orange-100 text-sm">מסעדות</div>
+              <div className="text-orange-100 text-sm">{t('common.restaurants')}</div>
             </div>
             <div>
               <div className="text-3xl font-bold">{stats.totalEpisodes}</div>
-              <div className="text-orange-100 text-sm">פרקים</div>
+              <div className="text-orange-100 text-sm">{t('common.episodes')}</div>
             </div>
             <div>
               <div className="text-2xl font-bold">{stats.topCuisines.length}</div>
-              <div className="text-orange-100 text-sm">סוגי מטבח</div>
+              <div className="text-orange-100 text-sm">{t('stats.cuisineTypes')}</div>
             </div>
             <div>
               <div className="text-2xl font-bold">{stats.topLocations.length}</div>
-              <div className="text-orange-100 text-sm">ערים</div>
+              <div className="text-orange-100 text-sm">{t('stats.cities')}</div>
             </div>
           </div>
         </div>
@@ -113,7 +115,7 @@ export function BentoHero({ featuredRestaurants, stats }: BentoHeroProps) {
         <div className="p-4 h-full flex flex-col">
           <div className="flex items-center gap-2 mb-3">
             <Users className="size-4" />
-            <h3 className="font-bold text-sm">מטבחים פופולריים</h3>
+            <h3 className="font-bold text-sm">{t('stats.popularCuisines')}</h3>
           </div>
           <div className="space-y-2 flex-1">
             {stats.topCuisines.slice(0, 3).map(([cuisine, count]) => (

--- a/web/src/components/restaurant-card.tsx
+++ b/web/src/components/restaurant-card.tsx
@@ -6,6 +6,7 @@ import { Separator } from "@/components/ui/separator"
 import { MapPin, Clock, Phone, Globe, Star, Heart, ChevronDown, ChevronUp } from "lucide-react"
 import { Restaurant } from "@/types/restaurant"
 import { useFavorites } from "@/contexts/favorites-context"
+import { useLanguage } from "@/contexts/LanguageContext"
 import { useState } from "react"
 
 interface RestaurantCardProps {
@@ -61,6 +62,7 @@ function getPriceRangeDisplay(priceRange: Restaurant['price_range']) {
 
 export function RestaurantCard({ restaurant }: RestaurantCardProps) {
   const { isFavorite, addFavorite, removeFavorite } = useFavorites()
+  const { t } = useLanguage()
   const restaurantId = restaurant.name_hebrew
   const isRestaurantFavorite = isFavorite(restaurantId)
   const [isExpanded, setIsExpanded] = useState(false)
@@ -142,7 +144,7 @@ export function RestaurantCard({ restaurant }: RestaurantCardProps) {
             <div>
               <h4 className="font-semibold mb-2 flex items-center gap-2">
                 <Star className="size-4" />
-                תפריט מומלץ
+                {t('restaurant.recommendedMenu')}
               </h4>
               <div className="space-y-2">
                 {restaurant.menu_items.slice(0, 3).map((item, index) => (
@@ -162,7 +164,7 @@ export function RestaurantCard({ restaurant }: RestaurantCardProps) {
                 ))}
                 {restaurant.menu_items.length > 3 && (
                   <p className="text-xs text-muted-foreground">
-                    +{restaurant.menu_items.length - 3} פריטים נוספים
+                    {t('restaurant.moreItems').replace('{count}', String(restaurant.menu_items.length - 3))}
                   </p>
                 )}
               </div>
@@ -171,7 +173,7 @@ export function RestaurantCard({ restaurant }: RestaurantCardProps) {
 
           {restaurant.special_features.length > 0 && (
             <div>
-              <h4 className="font-semibold mb-2">תכונות מיוחדות</h4>
+              <h4 className="font-semibold mb-2">{t('restaurant.specialFeatures')}</h4>
               <div className="flex flex-wrap gap-1">
                 {restaurant.special_features.map((feature, index) => (
                   <Badge key={index} variant="secondary" className="text-xs">
@@ -201,7 +203,7 @@ export function RestaurantCard({ restaurant }: RestaurantCardProps) {
               <div className="flex items-center gap-1">
                 <Globe className="size-3" />
                 <a href={restaurant.contact_info.website} target="_blank" rel="noopener noreferrer" className="hover:underline">
-                  אתר
+                  {t('common.website')}
                 </a>
               </div>
             )}
@@ -209,7 +211,7 @@ export function RestaurantCard({ restaurant }: RestaurantCardProps) {
 
           {restaurant.business_news && (
             <div className="bg-blue-50 dark:bg-blue-950/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800">
-              <h4 className="font-semibold text-blue-900 dark:text-blue-100 mb-1">חדשות עסקיות</h4>
+              <h4 className="font-semibold text-blue-900 dark:text-blue-100 mb-1">{t('restaurant.businessNews')}</h4>
               <p className="text-sm text-blue-800 dark:text-blue-200 text-right">{restaurant.business_news}</p>
             </div>
           )}
@@ -225,7 +227,7 @@ export function RestaurantCard({ restaurant }: RestaurantCardProps) {
               className="flex-1 flex items-center justify-center gap-1 px-3 py-2 bg-primary text-primary-foreground rounded text-sm hover:bg-primary/90 transition-colors"
             >
               <MapPin className="size-3" />
-              מפה
+              {t('common.map')}
             </button>
             <button
               onClick={(e) => {

--- a/web/src/components/restaurant-map.tsx
+++ b/web/src/components/restaurant-map.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { endpoints } from "@/lib/config"
+import { useLanguage } from "@/contexts/LanguageContext"
 
 interface RestaurantMapProps {
   restaurants: Restaurant[]
@@ -44,6 +45,7 @@ interface PlaceDetails {
 }
 
 export function RestaurantMap({ restaurants, selectedRestaurant, onRestaurantSelect }: RestaurantMapProps) {
+  const { t } = useLanguage()
   const mapRef = useRef<HTMLDivElement>(null)
   const [map, setMap] = useState<any>(null)
   const [markers, setMarkers] = useState<any[]>([])
@@ -334,7 +336,7 @@ export function RestaurantMap({ restaurants, selectedRestaurant, onRestaurantSel
         <CardContent className="p-6">
           <div className="text-center">
             <div className="text-red-500 text-4xl mb-4">🗺️</div>
-            <h3 className="text-lg font-semibold text-red-800 mb-2">שגיאה בטעינת המפה</h3>
+            <h3 className="text-lg font-semibold text-red-800 mb-2">{t('restaurant.mapError')}</h3>
             <p className="text-red-600">{error}</p>
           </div>
         </CardContent>
@@ -348,7 +350,7 @@ export function RestaurantMap({ restaurants, selectedRestaurant, onRestaurantSel
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <MapPin className="size-5 text-orange-500" />
-            מפת מסעדות
+            {t('common.map')}
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -357,7 +359,7 @@ export function RestaurantMap({ restaurants, selectedRestaurant, onRestaurantSel
               <div className="absolute inset-0 bg-white/80 backdrop-blur-sm z-10 flex items-center justify-center">
                 <div className="text-center">
                   <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500 mx-auto mb-2"></div>
-                  <p className="text-sm text-gray-600">טוען מפה...</p>
+                  <p className="text-sm text-gray-600">{t('restaurant.loadingMap')}</p>
                 </div>
               </div>
             )}
@@ -376,7 +378,9 @@ export function RestaurantMap({ restaurants, selectedRestaurant, onRestaurantSel
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Navigation className="size-5 text-blue-500" />
-              מסעדות על המפה ({enrichedRestaurants.filter(r => r.placeDetails).length} מתוך {enrichedRestaurants.length})
+              {t('restaurant.restaurantsOnMap')
+                .replace('{found}', String(enrichedRestaurants.filter(r => r.placeDetails).length))
+                .replace('{total}', String(enrichedRestaurants.length))}
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -410,11 +414,11 @@ export function RestaurantMap({ restaurants, selectedRestaurant, onRestaurantSel
                         className="bg-orange-500 hover:bg-orange-600"
                       >
                         <MapPin className="size-4 ml-1" />
-                        הצג במפה
+                        {t('restaurant.showOnMap')}
                       </Button>
                     ) : (
                       <Badge variant="outline" className="text-xs text-red-600">
-                        לא נמצא במפה
+                        {t('restaurant.notFoundOnMap')}
                       </Badge>
                     )}
                   </div>

--- a/web/src/components/visual-restaurant-card.tsx
+++ b/web/src/components/visual-restaurant-card.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge"
 import { MapPin, Heart, Star, Phone, Globe, Clock, ChevronDown, ChevronUp } from "lucide-react"
 import { Restaurant } from "@/types/restaurant"
 import { useFavorites } from "@/contexts/favorites-context"
+import { useLanguage } from "@/contexts/LanguageContext"
 import { OptimizedImage } from "./optimized-image"
 import { Separator } from "@/components/ui/separator"
 
@@ -64,6 +65,7 @@ export function VisualRestaurantCard({
   aspectRatio = "landscape"
 }: VisualRestaurantCardProps) {
   const { isFavorite, addFavorite, removeFavorite } = useFavorites()
+  const { t } = useLanguage()
   const restaurantId = restaurant.name_hebrew
   const isRestaurantFavorite = isFavorite(restaurantId)
   const [isExpanded, setIsExpanded] = useState(false)
@@ -183,7 +185,7 @@ export function VisualRestaurantCard({
               <div>
                 <h4 className="font-semibold mb-2 flex items-center gap-2">
                   <Star className="size-4" />
-                  תפריט מומלץ
+                  {t('restaurant.recommendedMenu')}
                 </h4>
                 <div className="space-y-2">
                   {restaurant.menu_items.slice(0, 3).map((item, index) => (
@@ -203,7 +205,7 @@ export function VisualRestaurantCard({
                   ))}
                   {restaurant.menu_items.length > 3 && (
                     <p className="text-xs text-muted-foreground">
-                      +{restaurant.menu_items.length - 3} פריטים נוספים
+                      {t('restaurant.moreItems').replace('{count}', String(restaurant.menu_items.length - 3))}
                     </p>
                   )}
                 </div>
@@ -212,7 +214,7 @@ export function VisualRestaurantCard({
 
             {restaurant.special_features.length > 0 && (
               <div>
-                <h4 className="font-semibold mb-2">תכונות מיוחדות</h4>
+                <h4 className="font-semibold mb-2">{t('restaurant.specialFeatures')}</h4>
                 <div className="flex flex-wrap gap-1">
                   {restaurant.special_features.map((feature, index) => (
                     <Badge key={index} variant="secondary" className="text-xs">
@@ -242,7 +244,7 @@ export function VisualRestaurantCard({
                 <div className="flex items-center gap-1">
                   <Globe className="size-3" />
                   <a href={restaurant.contact_info.website} target="_blank" rel="noopener noreferrer" className="hover:underline">
-                    אתר
+                    {t('common.website')}
                   </a>
                 </div>
               )}
@@ -250,7 +252,7 @@ export function VisualRestaurantCard({
 
             {restaurant.business_news && (
               <div className="bg-blue-50 dark:bg-blue-950/20 rounded-lg p-3 border border-blue-200 dark:border-blue-800">
-                <h4 className="font-semibold text-blue-900 dark:text-blue-100 mb-1">חדשות עסקיות</h4>
+                <h4 className="font-semibold text-blue-900 dark:text-blue-100 mb-1">{t('restaurant.businessNews')}</h4>
                 <p className="text-sm text-blue-800 dark:text-blue-200 text-right">{restaurant.business_news}</p>
               </div>
             )}
@@ -266,7 +268,7 @@ export function VisualRestaurantCard({
                 className="flex-1 flex items-center justify-center gap-1 px-3 py-2 bg-primary text-primary-foreground rounded text-sm hover:bg-primary/90 transition-colors"
               >
                 <MapPin className="size-3" />
-                מפה
+                {t('common.map')}
               </button>
               <button
                 onClick={(e) => {

--- a/web/src/lib/translations/en.json
+++ b/web/src/lib/translations/en.json
@@ -61,7 +61,15 @@
       "neighborhood": "Neighborhood",
       "allRegions": "All regions",
       "allCities": "All cities",
-      "allNeighborhoods": "All neighborhoods"
+      "allNeighborhoods": "All neighborhoods",
+      "text": "Text: {text}",
+      "location": "Location: {location}",
+      "cuisine": "Cuisine: {cuisine}",
+      "priceLabel": "Price: {price}",
+      "opinionLabel": "Opinion: {opinion}",
+      "dates": "Dates: {start} - {end}",
+      "activeFiltersTitle": "Active filters:",
+      "filterExpandHint": "(Click to expand)"
     },
     "cuisine": {
       "title": "Cuisine type",
@@ -77,7 +85,10 @@
       "midRangeRestaurants": "Mid-range restaurants",
       "expensiveRestaurants": "Expensive restaurants",
       "notSpecified": "Price range not mentioned",
-      "distribution": "Price distribution"
+      "distribution": "Price distribution",
+      "budgetSymbol": "Budget ₪",
+      "midRangeSymbol": "Mid-range ₪₪",
+      "expensiveSymbol": "Expensive ₪₪₪"
     },
     "opinion": {
       "positive": "Positive 👍",
@@ -92,7 +103,12 @@
     "businessNews": "Business news",
     "moreItems": "+{count} more items",
     "highlyRecommended": "Highly recommended",
-    "leadingRestaurants": "Leading restaurants"
+    "leadingRestaurants": "Leading restaurants",
+    "showOnMap": "Show on map",
+    "notFoundOnMap": "Not found on map",
+    "loadingMap": "Loading map...",
+    "mapError": "Error loading map",
+    "restaurantsOnMap": "Restaurants on map ({found} of {total})"
   },
   "layout": {
     "masonry": "Masonry",
@@ -105,7 +121,9 @@
   },
   "stats": {
     "systemStats": "System statistics",
-    "cuisineTypes": "Cuisine types"
+    "cuisineTypes": "Cuisine types",
+    "cities": "Cities",
+    "popularCuisines": "Popular cuisines"
   },
   "youtube": {
     "invalidUrl": "Please enter a valid YouTube URL",

--- a/web/src/lib/translations/he.json
+++ b/web/src/lib/translations/he.json
@@ -61,7 +61,15 @@
       "neighborhood": "שכונה",
       "allRegions": "כל האזורים",
       "allCities": "כל העיירות",
-      "allNeighborhoods": "כל השכונות"
+      "allNeighborhoods": "כל השכונות",
+      "text": "טקסט: {text}",
+      "location": "מיקום: {location}",
+      "cuisine": "מטבח: {cuisine}",
+      "priceLabel": "מחיר: {price}",
+      "opinionLabel": "דעה: {opinion}",
+      "dates": "תאריכים: {start} - {end}",
+      "activeFiltersTitle": "מסננים פעילים:",
+      "filterExpandHint": "(לחץ להרחבה)"
     },
     "cuisine": {
       "title": "סוג מטבח",
@@ -77,7 +85,10 @@
       "midRangeRestaurants": "מסעדות בתקציב בינוני",
       "expensiveRestaurants": "מסעדות יקרות",
       "notSpecified": "טווח מחיר לא צוין",
-      "distribution": "התפלגות מחירים"
+      "distribution": "התפלגות מחירים",
+      "budgetSymbol": "זול ₪",
+      "midRangeSymbol": "בינוני ₪₪",
+      "expensiveSymbol": "יקר ₪₪₪"
     },
     "opinion": {
       "positive": "חיובית 👍",
@@ -92,7 +103,12 @@
     "businessNews": "חדשות עסקיות",
     "moreItems": "+{count} פריטים נוספים",
     "highlyRecommended": "מומלץ ביותר",
-    "leadingRestaurants": "מסעדות מובילות"
+    "leadingRestaurants": "מסעדות מובילות",
+    "showOnMap": "הצג במפה",
+    "notFoundOnMap": "לא נמצא במפה",
+    "loadingMap": "טוען מפה...",
+    "mapError": "שגיאה בטעינת המפה",
+    "restaurantsOnMap": "מסעדות על המפה ({found} מתוך {total})"
   },
   "layout": {
     "masonry": "מזונרי",
@@ -105,7 +121,9 @@
   },
   "stats": {
     "systemStats": "סטטיסטיקות מערכת",
-    "cuisineTypes": "סוגי מטבח"
+    "cuisineTypes": "סוגי מטבח",
+    "cities": "ערים",
+    "popularCuisines": "מטבחים פופולריים"
   },
   "youtube": {
     "invalidUrl": "נא להזין כתובת YouTube תקינה",
@@ -114,6 +132,6 @@
     "analysisStarted": "הניתוח התחיל בהצלחה!..."
   },
   "errors": {
-    "failedToLoadMaps": "Failed to load Google Maps"
+    "failedToLoadMaps": "נכשל בטעינת Google Maps"
   }
 }


### PR DESCRIPTION
Fixed language toggle issues where Hebrew text was still showing when
English was selected. Made the following changes:

- Added missing translation keys to en.json and he.json for:
  - Restaurant card labels (menu, features, business news, website, map)
  - Map component labels (loading, error, show on map, not found)
  - Filter labels (active filters, expand hint)
  - Statistics labels (system stats, cities, popular cuisines)
  - Price range symbols with currency

- Updated components to use useLanguage hook and t() function:
  - restaurant-card.tsx: Translated menu, features, business news, buttons
  - visual-restaurant-card.tsx: Same translations as restaurant-card
  - restaurant-map.tsx: Translated map UI, loading states, buttons
  - bento-hero.tsx: Translated stats section and badge labels
  - animated-filters.tsx: Translated filter header and clear button

All user-facing text in these core components now properly responds to
the language toggle between English and Hebrew.