### PR TITLE
fix: Update youtube-transcript-api from v0.6 to v1.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-youtube-transcript-api==0.6.2
+youtube-transcript-api>=1.0.0
 openai==1.54.4
 python-dotenv==1.0.0
 google-api-python-client==2.108.0


### PR DESCRIPTION
## Summary

- Updates `youtube-transcript-api` library from v0.6.x to v1.x to fix breaking API changes
- Migrates from static methods to instance-based API
- Updates response parsing from dict access to object attributes

## Changes

| Old (0.6.x) | New (1.2.x) |
|-------------|-------------|
| `YouTubeTranscriptApi.get_transcript(...)` | `YouTubeTranscriptApi().fetch(...)` |
| `YouTubeTranscriptApi.list_transcripts(...)` | `YouTubeTranscriptApi().list(...)` |
| `segment['text']` | `snippet.text` |

## Files Changed

- `src/youtube_transcript_collector.py` - Updated `get_transcript()` and `health_check()` methods
- `requirements.txt` - Changed `youtube-transcript-api==0.6.2` to `>=1.0.0`
- `tests/test_youtube_transcript.py` - Updated mocks to use new API structure

## Test plan

- [x] All 20 existing tests pass
- [x] Manual verification with real YouTube video transcript fetching
- [x] Health check endpoint works with new API

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)