### PR TITLE
fix: Use Node.js start script instead of uvicorn for Railway deployment

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,10 +4,10 @@
   "description": "Backend API for Where2Eat Restaurant Discovery System",
   "main": "index.js",
   "scripts": {
-    "start": "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}",
-    "dev": "uvicorn main:app --host 0.0.0.0 --port 8000 --reload",
-    "start:legacy": "node index.js",
-    "dev:legacy": "nodemon index.js",
+    "start": "node index.js",
+    "dev": "nodemon index.js",
+    "start:fastapi": "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}",
+    "dev:fastapi": "uvicorn main:app --host 0.0.0.0 --port 8000 --reload",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
The start script was running `uvicorn main:app` (Python command) but Railway
detects package.json as Node.js project and only installs npm dependencies.
This caused the server to crash with "uvicorn: command not found".

Changed start script to run Express.js server with `node index.js`.
FastAPI scripts renamed to :fastapi variants for manual use.

https://claude.ai/code/session_01RJA1yY98MuZKzFco9WAM57