### PR TITLE
fix: Resolve module import error on Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy requirements
+COPY api/requirements.txt ./api-requirements.txt
+RUN pip install --no-cache-dir -r api-requirements.txt
+
+# Install src dependencies for transcript collector and analyzers
+RUN pip install --no-cache-dir \
+    youtube-transcript-api \
+    anthropic \
+    openai \
+    google-api-python-client \
+    python-dotenv \
+    httpx
+
+# Copy source code
+COPY src ./src
+COPY api ./api
+
+# Set working directory to api
+WORKDIR /app/api
+
+EXPOSE 8080
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/api/main.py
+++ b/api/main.py
@@ -18,8 +18,15 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Add src to path for Python imports
-SRC_DIR = (Path(__file__).parent.parent / "src").resolve()
-sys.path.insert(0, str(SRC_DIR))
+# Handle both local dev (api/main.py) and Railway deployment (/app/main.py)
+possible_src_paths = [
+    Path(__file__).parent.parent / "src",  # Local: api/../src
+    Path(__file__).parent / "src",          # Railway: /app/src
+]
+for src_path in possible_src_paths:
+    if src_path.exists():
+        sys.path.insert(0, str(src_path.resolve()))
+        break
 
 from models.analyze import DEFAULT_VIDEO_URL
 

--- a/api/routers/analyze.py
+++ b/api/routers/analyze.py
@@ -20,8 +20,15 @@ from models.analyze import (
 )
 
 # Add src to path for imports
-SRC_DIR = (Path(__file__).parent.parent.parent / "src").resolve()
-sys.path.insert(0, str(SRC_DIR))
+# Handle both local dev (api/routers/analyze.py) and Railway deployment
+possible_src_paths = [
+    Path(__file__).parent.parent.parent / "src",  # Local: api/routers/../../src
+    Path(__file__).parent.parent / "src",          # Railway: /app/routers/../src
+]
+for src_path in possible_src_paths:
+    if src_path.exists():
+        sys.path.insert(0, str(src_path.resolve()))
+        break
 
 router = APIRouter(tags=["Analysis"])
 

--- a/api/routers/health.py
+++ b/api/routers/health.py
@@ -7,8 +7,15 @@ from datetime import datetime
 from fastapi import APIRouter
 
 # Add src to path for imports
-SRC_DIR = (Path(__file__).parent.parent.parent / "src").resolve()
-sys.path.insert(0, str(SRC_DIR))
+# Handle both local dev (api/routers/health.py) and Railway deployment
+possible_src_paths = [
+    Path(__file__).parent.parent.parent / "src",  # Local: api/routers/../../src
+    Path(__file__).parent.parent / "src",          # Railway: /app/routers/../src
+]
+for src_path in possible_src_paths:
+    if src_path.exists():
+        sys.path.insert(0, str(src_path.resolve()))
+        break
 
 router = APIRouter(tags=["Health"])
 

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed `ModuleNotFoundError: No module named 'youtube_transcript_collector'` on Railway startup
- Updated sys.path logic in `main.py` and routers to check multiple possible src directory locations
- Added `Dockerfile` to properly copy both `api/` and `src/` directories to the container
- Added `railway.json` to configure Railway to use the Dockerfile

## Root Cause
The path resolution (`Path(__file__).parent.parent / "src"`) assumed the local directory structure where `main.py` is in `api/` subdirectory. In Railway, files were deployed differently, causing the `src/` directory to not be found.

## Test plan
- [ ] Deploy to Railway and verify the server starts without module import errors
- [ ] Verify `/health` endpoint returns OK
- [ ] Verify `/api/youtube-transcript/health` endpoint works
- [ ] Verify video analysis works on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)