### PR TITLE
fix: Remove 8000 char transcript truncation that limited restaurant extraction

### DIFF
--- a/src/claude_restaurant_analyzer.py
+++ b/src/claude_restaurant_analyzer.py
@@ -254,11 +254,13 @@ class ClaudeRestaurantAnalyzer:
         self.logger.info("🤖 Attempting to call Claude Task agent for restaurant analysis")
         
         # Create the detailed task prompt
+        # Use larger context window to capture all restaurants (previous bug: 8000 char limit)
+        max_length = 100000
         task_prompt = f"""
         You are a specialized restaurant analysis agent. Analyze this Hebrew food podcast transcript and extract ALL restaurants mentioned by name.
-        
+
         TRANSCRIPT SEGMENT:
-        {transcript_text[:8000]}{'...' if len(transcript_text) > 8000 else ''}
+        {transcript_text[:max_length]}{'...' if len(transcript_text) > max_length else ''}
         
         TASK: Extract every restaurant, café, bistro, food truck, or dining establishment that is mentioned by its actual name in this Hebrew text.
         

--- a/src/unified_restaurant_analyzer.py
+++ b/src/unified_restaurant_analyzer.py
@@ -290,9 +290,10 @@ class UnifiedRestaurantAnalyzer:
 
     def _create_analysis_prompt(self, transcript_text: str) -> str:
         """Create the analysis prompt for the LLM"""
-        
-        # Truncate transcript if too long for context
-        max_transcript_length = 8000
+
+        # Use chunk_size from config to ensure we analyze the full transcript
+        # Previous bug: truncated to 8000 chars which missed most restaurants
+        max_transcript_length = self.config.chunk_size
         truncated_transcript = transcript_text[:max_transcript_length]
         if len(transcript_text) > max_transcript_length:
             truncated_transcript += "..."


### PR DESCRIPTION
The restaurant analyzers were truncating transcripts to only 8000 characters
before sending them to the LLM, causing most restaurants mentioned later in
the podcast to be missed. This fix:

- unified_restaurant_analyzer.py: Now uses config.chunk_size (100K default)
- claude_restaurant_analyzer.py: Increased limit to 100K characters

This ensures the full transcript is analyzed and all restaurants are found.