### PR TITLE
Load environment variables from project root in MCP servers

### DIFF
--- a/.claude/mcp-servers/railway_server.py
+++ b/.claude/mcp-servers/railway_server.py
@@ -11,6 +11,12 @@ import logging
 import asyncio
 import httpx
 from typing import Any, Sequence
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Load .env from project root
+env_path = Path(__file__).parent.parent.parent / ".env"
+load_dotenv(env_path)
 
 # Configure logging to stderr (required for MCP)
 logging.basicConfig(

--- a/.claude/mcp-servers/vercel_server.py
+++ b/.claude/mcp-servers/vercel_server.py
@@ -11,6 +11,12 @@ import logging
 import asyncio
 import httpx
 from typing import Any, Sequence
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Load .env from project root
+env_path = Path(__file__).parent.parent.parent / ".env"
+load_dotenv(env_path)
 
 # Configure logging to stderr (required for MCP)
 logging.basicConfig(


### PR DESCRIPTION
## Summary
Added environment variable loading from the project root `.env` file to both Railway and Vercel MCP servers. This ensures that API keys and other configuration values are properly loaded when these servers start up.

## Changes
- Added `pathlib.Path` and `python-dotenv` imports to both `railway_server.py` and `vercel_server.py`
- Implemented `.env` file loading from the project root directory (`../../.env` relative to each server file)
- Applied identical changes to both MCP server implementations for consistency

## Implementation Details
- Uses `Path(__file__).parent.parent.parent / ".env"` to resolve the `.env` file location relative to the server files' position in the `.claude/mcp-servers/` directory
- Calls `load_dotenv(env_path)` to load environment variables before any server initialization
- This allows the servers to access credentials and configuration from environment variables without hardcoding them