### PR TITLE
fix: Resolve module import collision between api/models and src/models

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -28,8 +28,9 @@ for src_path in possible_src_paths:
     if src_path.exists():
         resolved = str(src_path.resolve())
         if resolved not in sys.path:
-            sys.path.append(resolved)
-        print(f"[PATH] Added to sys.path: {src_path.resolve()}")
+            # Insert at position 0 to ensure src/models takes priority over api/models
+            sys.path.insert(0, resolved)
+        print(f"[PATH] Added to sys.path (position 0): {src_path.resolve()}")
         break
 else:
     print(f"[PATH] Warning: Could not find src directory. Tried: {[str(p) for p in possible_src_paths]}")

--- a/api/routers/restaurants.py
+++ b/api/routers/restaurants.py
@@ -43,8 +43,12 @@ def get_db_session():
     try:
         import sys
         src_path = Path(__file__).parent.parent.parent / "src"
-        if str(src_path) not in sys.path:
-            sys.path.insert(0, str(src_path))
+        src_path_str = str(src_path.resolve())
+        # Ensure src is at position 0 so src/models is found before api/models
+        if src_path_str in sys.path:
+            sys.path.remove(src_path_str)
+        sys.path.insert(0, src_path_str)
+        # Import from src/models (not api/models)
         from models import get_db_session as models_get_db_session
         return models_get_db_session()
     except Exception as e:


### PR DESCRIPTION
## Summary
- Fixes the database session import error causing no restaurants to display
- Resolves Python module naming collision between `api/models/` and `src/models/`
- Ensures `src/` directory is at position 0 in `sys.path` for correct module resolution

## Root Cause
In Docker/Railway, the working directory is `/app/api`, so when the code did `from models import get_db_session`, Python found `api/models/__init__.py` first (Pydantic schemas) instead of `src/models/__init__.py` (SQLAlchemy ORM with `get_db_session`).

## Changes
- `api/main.py`: Changed `sys.path.append()` to `sys.path.insert(0, ...)` to prioritize `src/`
- `api/routers/restaurants.py`: Always ensure `src/` is at position 0 before importing from `models`

Fixes #54

## Test plan
- [x] Python syntax check passes
- [x] Node.js API syntax check passes
- [ ] CI tests pass
- [ ] Deploy to Railway and verify restaurants load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)