### PR TITLE
Recovery Phase 2: Pipeline activation tooling

### DIFF
--- a/docs/recovery-phase2-pipeline-activation.md
+++ b/docs/recovery-phase2-pipeline-activation.md
@@ -102,11 +102,10 @@ curl https://where2eat-production.up.railway.app/api/restaurants
 All 8 tests pass.
 
 ## Known Issues
-- `YOUTUBE_DATA_API_KEY` must be set on Railway for playlist video fetching to work. Without it, the scheduler's `_fetch_playlist_videos()` returns empty.
 - The scheduler runs poll every 12h by default. First poll won't happen until the interval fires. Use `poll` command or the `/check` endpoint to trigger immediately.
 - Google Places API is returning `REQUEST_DENIED` — needs manual verification in Google Cloud Console.
+- Video fetching uses `yt-dlp` (no API key needed). Ensure `yt-dlp` is installed in the deployment environment.
 
 ## Environment Variables Required on Railway
-- `YOUTUBE_DATA_API_KEY` — For fetching playlist videos via YouTube Data API
 - `GOOGLE_PLACES_API_KEY` — For restaurant location enrichment (currently failing)
 - `ANTHROPIC_API_KEY` — For Claude-based transcript analysis

--- a/scripts/seed_subscription.py
+++ b/scripts/seed_subscription.py
@@ -4,16 +4,19 @@ Seed subscription script for Where2Eat pipeline.
 
 Usage:
     # Add a playlist subscription
-    python scripts/seed_subscription.py --url "https://www.youtube.com/playlist?list=PLxxx" --name "My Playlist"
+    python scripts/seed_subscription.py add --url "https://www.youtube.com/playlist?list=PLxxx" --name "My Playlist"
 
     # Add a channel subscription
-    python scripts/seed_subscription.py --url "https://www.youtube.com/@ChannelName" --name "My Channel"
+    python scripts/seed_subscription.py add --url "https://www.youtube.com/@ChannelName" --name "My Channel"
 
     # List all subscriptions
-    python scripts/seed_subscription.py --list
+    python scripts/seed_subscription.py list
 
     # Trigger immediate poll for all active subscriptions
-    python scripts/seed_subscription.py --poll
+    python scripts/seed_subscription.py poll
+
+    # Show pipeline status
+    python scripts/seed_subscription.py status
 
 This script is designed to be run:
 - Locally against the local database
@@ -25,7 +28,6 @@ Environment:
 """
 
 import argparse
-import json
 import os
 import sys
 from pathlib import Path

--- a/tests/test_seed_subscription.py
+++ b/tests/test_seed_subscription.py
@@ -3,8 +3,6 @@
 import sys
 import pytest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
-from argparse import Namespace
 
 # Add scripts and src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))


### PR DESCRIPTION
## Summary
- Add `scripts/seed_subscription.py` CLI for managing subscriptions and triggering pipeline
- Auto-normalize YouTube video+list URLs to proper playlist format
- Comprehensive activation runbook in `docs/recovery-phase2-pipeline-activation.md`

## How to activate (after Phase 1 is deployed)
```bash
# Seed the playlist
python scripts/seed_subscription.py add \
  --url "https://www.youtube.com/watch?v=J6Akd1bXiWM&list=PLZPgleW4baxrsrU-metYY1imJ85uH9FNg" \
  --name "Hebrew Food Podcast" --priority 3

# Trigger immediate poll
python scripts/seed_subscription.py poll
```

## Test plan
- [x] 8 new tests in `tests/test_seed_subscription.py` — all passing
- [ ] Run seed script on Railway after Phase 1 deploy
- [ ] Verify scheduler picks up subscription and queues videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)