### PR TITLE
Fix seed when episode_id is null

### DIFF
--- a/api/routers/episodes.py
+++ b/api/routers/episodes.py
@@ -186,7 +186,7 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
     if not video_id:
         raise HTTPException(status_code=400, detail="Missing episode.video_id")
 
-    episode_id = ep.get('episode_id', str(uuid.uuid4()))
+    episode_id = ep.get('episode_id') or str(uuid.uuid4())
 
     # Create episode
     try:


### PR DESCRIPTION
## Summary
- `ep.get('episode_id', uuid4())` returns `None` when the key exists but is explicitly `null` — changed to `ep.get('episode_id') or uuid4()`
- This caused all 10 new episode seeds to silently fail with 0 mentions

## Test plan
- [x] Verified locally that `None or str(uuid4())` produces a valid UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)