### PR TITLE
feat: chatbot agent with real-time Ontopo & Tabit availability

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -51,6 +51,7 @@ from routers import (
     admin_subscriptions_router,
     admin_pipeline_router,
     episodes_router,
+    chat_router,
 )
 
 
@@ -1007,6 +1008,7 @@ app.include_router(admin_router)
 app.include_router(admin_subscriptions_router)
 app.include_router(admin_pipeline_router)
 app.include_router(episodes_router)
+app.include_router(chat_router)
 
 
 @app.get("/api/subscriptions")

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,3 +24,6 @@ python-dotenv>=1.0.0
 
 # CORS
 # (built into FastAPI)
+
+# AI
+anthropic>=0.40.0

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -10,6 +10,7 @@ from .admin import router as admin_router
 from .admin_subscriptions import router as admin_subscriptions_router
 from .admin_pipeline import router as admin_pipeline_router
 from .episodes import router as episodes_router
+from .chat import router as chat_router
 
 __all__ = [
     "restaurants_router",
@@ -22,4 +23,5 @@ __all__ = [
     "admin_subscriptions_router",
     "admin_pipeline_router",
     "episodes_router",
+    "chat_router",
 ]

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -1,0 +1,301 @@
+"""
+Chat Agent endpoint — POST /api/chat/message
+
+Uses Claude Opus 4.6 with tool_use to answer natural language restaurant queries,
+search the where2eat DB, and check real-time availability on Ontopo and Tabit.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, date
+from typing import Optional, List
+
+import httpx
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/chat", tags=["Chat"])
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+class ChatMessage(BaseModel):
+    role: str   # "user" | "assistant"
+    content: str
+
+
+class ChatRequest(BaseModel):
+    message: str
+    session_id: Optional[str] = None
+    history: List[ChatMessage] = []
+    context: Optional[dict] = None  # {"party_size": 2, "date": "2026-04-24"}
+
+
+class ChatResponse(BaseModel):
+    reply: str
+    session_id: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+RESTAURANT_API = "https://where2eat-production.up.railway.app"
+RESTAURANT_ORIGIN = "https://where2eat.rest"
+
+
+async def _tool_search_restaurants(city: str, cuisine: str = "",
+                                    occasion: str = "", limit: int = 8) -> str:
+    """Search where2eat DB for restaurants."""
+    params = {"limit": str(limit)}
+    if city:
+        params["city"] = city
+    if cuisine:
+        params["cuisine_type"] = cuisine
+
+    query_parts = [p for p in [city, cuisine, occasion] if p]
+    if query_parts:
+        params["query"] = " ".join(query_parts)
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{RESTAURANT_API}/api/restaurants/search",
+                params=params,
+                headers={"Origin": RESTAURANT_ORIGIN},
+                timeout=10,
+            )
+            data = resp.json()
+            restaurants = data.get("restaurants", [])
+
+        # Return lean summary for Claude
+        result = []
+        for r in restaurants[:8]:
+            result.append({
+                "id": r.get("id"),
+                "name_hebrew": r.get("name_hebrew"),
+                "name_english": r.get("name_english"),
+                "city": r.get("city"),
+                "cuisine_type": r.get("cuisine_type"),
+                "google_rating": r.get("google_rating"),
+                "description": (r.get("description") or "")[:200],
+                "ontopo_slug": r.get("ontopo_slug"),
+                "tabit_org_id": r.get("tabit_org_id"),
+                "address": r.get("address"),
+            })
+        return json.dumps(result, ensure_ascii=False)
+    except Exception as e:
+        logger.error(f"Restaurant search failed: {e}")
+        return json.dumps({"error": str(e)})
+
+
+async def _tool_check_ontopo(ontopo_slug: str, date: str,
+                              time: str, party_size: int = 2) -> str:
+    """Check Ontopo availability."""
+    from services.ontopo import check_availability
+    try:
+        result = await check_availability(
+            numeric_slug=ontopo_slug,
+            date=date.replace("-", ""),   # YYYY-MM-DD → YYYYMMDD
+            time_str=time.replace(":", ""),  # HH:MM → HHMM
+            party_size=party_size,
+        )
+        # Return lean result for Claude
+        return json.dumps({
+            "available": result["available"],
+            "slots": result["slots"][:5],
+            "recommended": result["recommended"][:2],
+            "alternative_dates": result["alternative_dates"][:3],
+            "booking_url": result["booking_url"],
+        }, ensure_ascii=False)
+    except Exception as e:
+        logger.error(f"Ontopo check failed: {e}")
+        return json.dumps({"available": False, "error": str(e)})
+
+
+async def _tool_check_tabit(tabit_org_id: str, date: str,
+                             time: str, party_size: int = 2) -> str:
+    """Check Tabit availability."""
+    from services.tabit import check_availability
+    try:
+        result = await check_availability(
+            org_id=tabit_org_id,
+            date=date,           # YYYY-MM-DD
+            time_str=time,       # HH:MM
+            party_size=party_size,
+        )
+        return json.dumps({
+            "available": result["available"],
+            "slots": result["slots"][:3],
+            "alternative_slots": result["alternative_slots"][:3],
+        }, ensure_ascii=False)
+    except Exception as e:
+        logger.error(f"Tabit check failed: {e}")
+        return json.dumps({"available": False, "error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions for Claude
+# ---------------------------------------------------------------------------
+
+TOOLS = [
+    {
+        "name": "search_restaurants",
+        "description": "חפש מסעדות ב-where2eat לפי עיר, סוג מטבח ואוקיישן. מחזיר רשימה של מסעדות מומלצות כולל ontopo_slug ו-tabit_org_id אם יש.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "עיר בעברית: תל אביב, ירושלים, חיפה וכו'"},
+                "cuisine": {"type": "string", "description": "סוג מטבח: איטלקי, יפני, ים תיכוני וכו'"},
+                "occasion": {"type": "string", "description": "אוקיישן: דייט, משפחה, עסקי, חברים וכו'"},
+                "limit": {"type": "integer", "description": "מספר תוצאות (ברירת מחדל 8)", "default": 8},
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "check_ontopo",
+        "description": "בדוק זמינות מקומות ב-Ontopo למסעדה ספציפית. read-only — לא יוצר הזמנה.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "ontopo_slug": {"type": "string", "description": "המזהה המספרי של המסעדה ב-Ontopo (מ-search_restaurants)"},
+                "date": {"type": "string", "description": "תאריך בפורמט YYYY-MM-DD"},
+                "time": {"type": "string", "description": "שעה בפורמט HH:MM (24h), למשל 20:00"},
+                "party_size": {"type": "integer", "description": "מספר סועדים", "default": 2},
+            },
+            "required": ["ontopo_slug", "date", "time"],
+        },
+    },
+    {
+        "name": "check_tabit",
+        "description": "בדוק זמינות מקומות ב-Tabit למסעדה ספציפית.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "tabit_org_id": {"type": "string", "description": "מזהה הארגון ב-Tabit (מ-search_restaurants)"},
+                "date": {"type": "string", "description": "תאריך בפורמט YYYY-MM-DD"},
+                "time": {"type": "string", "description": "שעה בפורמט HH:MM (24h), למשל 20:00"},
+                "party_size": {"type": "integer", "description": "מספר סועדים", "default": 2},
+            },
+            "required": ["tabit_org_id", "date", "time"],
+        },
+    },
+]
+
+TOOL_HANDLERS = {
+    "search_restaurants": _tool_search_restaurants,
+    "check_ontopo": _tool_check_ontopo,
+    "check_tabit": _tool_check_tabit,
+}
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+def _build_system_prompt() -> str:
+    today = date.today().strftime("%A, %B %d, %Y")
+    return f"""אתה עוזר מסעדות חכם של where2eat.rest. היום: {today}.
+
+יש לך גישה לכלים:
+- search_restaurants: חיפוש מסעדות ב-where2eat (מומלצות מפודקאסטים על אוכל)
+- check_ontopo: בדיקת זמינות אמיתית ב-Ontopo (read-only)
+- check_tabit: בדיקת זמינות אמיתית ב-Tabit
+
+הנחיות:
+1. הבן את הבקשה — עיר, תאריך/יום, מספר סועדים, אוקיישן, תקציב, העדפות
+2. חפש מסעדות מתאימות (search_restaurants)
+3. לכל מסעדה שיש לה ontopo_slug — בדוק זמינות (check_ontopo)
+4. לכל מסעדה שיש לה tabit_org_id — בדוק זמינות (check_tabit)
+5. הצג עד 3-4 מסעדות, ממוינות: קודם אלה עם מקום מאושר
+6. לכל מסעדה: שם, תיאור קצר, שעות פנויות, לינק הזמנה
+7. אם אין מקום — הצע תאריכים חלופיים
+8. היה תמציתי, חם וישיר — כמו חבר שמכיר את המסעדות
+
+אם לא ציינו תאריך — שאל מתי, או הנח היום בערב.
+אם לא ציינו מספר סועדים — הנח 2.
+ענה תמיד בעברית אלא אם שואלים באנגלית."""
+
+
+# ---------------------------------------------------------------------------
+# Main endpoint
+# ---------------------------------------------------------------------------
+
+@router.post("/message", response_model=ChatResponse)
+async def chat_message(request: ChatRequest):
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY not configured")
+
+    try:
+        import anthropic
+    except ImportError:
+        raise HTTPException(status_code=500, detail="anthropic package not installed")
+
+    client = anthropic.AsyncAnthropic(api_key=api_key)
+
+    # Build messages history
+    messages = []
+    for msg in request.history:
+        messages.append({"role": msg.role, "content": msg.content})
+    messages.append({"role": "user", "content": request.message})
+
+    system = _build_system_prompt()
+
+    # Agentic loop
+    MAX_ITERATIONS = 6
+    for _ in range(MAX_ITERATIONS):
+        response = await client.messages.create(
+            model="claude-opus-4-6",
+            max_tokens=2048,
+            system=system,
+            tools=TOOLS,
+            messages=messages,
+        )
+
+        if response.stop_reason == "end_turn":
+            # Extract final text
+            text = next(
+                (b.text for b in response.content if b.type == "text"), ""
+            )
+            return ChatResponse(reply=text, session_id=request.session_id)
+
+        if response.stop_reason != "tool_use":
+            break
+
+        # Append assistant response
+        messages.append({"role": "assistant", "content": response.content})
+
+        # Execute tools
+        tool_results = []
+        for block in response.content:
+            if block.type != "tool_use":
+                continue
+
+            handler = TOOL_HANDLERS.get(block.name)
+            if not handler:
+                result = json.dumps({"error": f"Unknown tool: {block.name}"})
+            else:
+                try:
+                    result = await handler(**block.input)
+                except Exception as e:
+                    logger.error(f"Tool {block.name} failed: {e}")
+                    result = json.dumps({"error": str(e)})
+
+            tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": result,
+            })
+
+        messages.append({"role": "user", "content": tool_results})
+
+    # Fallback
+    last_text = next(
+        (b.text for b in response.content if b.type == "text"), ""
+    )
+    return ChatResponse(reply=last_text or "מצטער, לא הצלחתי לעבד את הבקשה.", session_id=request.session_id)

--- a/api/services/__init__.py
+++ b/api/services/__init__.py
@@ -1,0 +1,1 @@
+"""API services."""

--- a/api/services/ontopo.py
+++ b/api/services/ontopo.py
@@ -1,0 +1,138 @@
+"""
+Ontopo availability service.
+
+Uses the public Ontopo REST API (ontopo.com, not .co.il which is CF-protected).
+Anonymous JWT auth — no account required, no reservation created.
+"""
+
+import time
+import logging
+import httpx
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+ONTOPO_BASE = "https://ontopo.com/api"
+_token_cache: dict = {"token": None, "expires_at": 0}
+
+
+async def _get_token(client: httpx.AsyncClient) -> str:
+    """Get or refresh anonymous JWT token (valid ~15 min)."""
+    now = time.time()
+    if _token_cache["token"] and now < _token_cache["expires_at"] - 60:
+        return _token_cache["token"]
+
+    resp = await client.post(f"{ONTOPO_BASE}/loginAnonymously", timeout=10)
+    resp.raise_for_status()
+    token = resp.json()["jwt_token"]
+    _token_cache["token"] = token
+    _token_cache["expires_at"] = now + 14 * 60  # 14 min to be safe
+    return token
+
+
+async def resolve_slug(name_slug: str) -> Optional[str]:
+    """Resolve a human-readable slug to Ontopo's numeric ID."""
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.post(
+                f"{ONTOPO_BASE}/slug_content",
+                json={"slug": name_slug},
+                timeout=8,
+            )
+            data = resp.json()
+            return data.get("slug") if data.get("slug") else None
+        except Exception as e:
+            logger.warning(f"Ontopo slug resolve failed for {name_slug}: {e}")
+            return None
+
+
+async def check_availability(
+    numeric_slug: str,
+    date: str,           # YYYYMMDD
+    time_str: str,       # HHMM (24h)
+    party_size: int = 2,
+) -> dict:
+    """
+    Check availability for a restaurant on Ontopo.
+    Returns structured result — no reservation is created.
+
+    Result format:
+    {
+        "available": bool,
+        "slots": [{"area": str, "time": str, "method": str}],
+        "recommended": [{"area": str, "time": str}],
+        "alternative_dates": ["YYYY-MM-DD HH:MM", ...],
+        "booking_url": str,
+        "raw": dict,
+    }
+    """
+    async with httpx.AsyncClient() as client:
+        try:
+            token = await _get_token(client)
+            resp = await client.post(
+                f"{ONTOPO_BASE}/availability_search",
+                headers={"token": token},
+                json={
+                    "slug": str(numeric_slug),
+                    "locale": "he",
+                    "criteria": {
+                        "size": str(party_size),
+                        "date": date,
+                        "time": time_str,
+                    },
+                },
+                timeout=10,
+            )
+            data = resp.json()
+        except Exception as e:
+            logger.error(f"Ontopo availability check failed: {e}")
+            return {"available": False, "error": str(e), "slots": [], "alternative_dates": []}
+
+    # Parse slots
+    slots = []
+    for area in data.get("areas", []):
+        area_name = area.get("name") or area.get("id", "")
+        for option in area.get("options", []):
+            method = option.get("method", "")
+            t = option.get("time", "")
+            slots.append({
+                "area": area_name,
+                "time": f"{t[:2]}:{t[2:]}" if len(t) == 4 else t,
+                "method": method,  # "seat" | "standby" | "disabled"
+            })
+
+    available_slots = [s for s in slots if s["method"] == "seat"]
+
+    # Parse recommended
+    recommended = []
+    for r in data.get("recommended", []):
+        if r.get("method") == "seat":
+            t = r.get("time", "")
+            recommended.append({
+                "area": r.get("id", ""),
+                "time": f"{t[:2]}:{t[2:]}" if len(t) == 4 else t,
+            })
+
+    # Parse alternative dates
+    alt_dates = []
+    for d in data.get("dates", []):
+        if len(d) >= 8:
+            date_part = d[:8]
+            time_part = d[8:12] if len(d) >= 12 else "2000"
+            formatted = f"{date_part[6:8]}/{date_part[4:6]}/{date_part[:4]} {time_part[:2]}:{time_part[2:]}"
+            alt_dates.append(formatted)
+
+    booking_url = (
+        f"https://ontopo.com/he/il/page/{numeric_slug}"
+        f"?date={date}&time={time_str}&size={party_size}"
+    )
+
+    return {
+        "available": len(available_slots) > 0,
+        "slots": available_slots,
+        "all_slots": slots,
+        "recommended": recommended,
+        "alternative_dates": alt_dates[:5],
+        "booking_url": booking_url,
+        "raw": data,
+    }

--- a/api/services/tabit.py
+++ b/api/services/tabit.py
@@ -1,0 +1,119 @@
+"""
+Tabit availability service.
+
+Uses the public Tabit API (tgm-api.tabit.cloud).
+No auth required for read operations.
+Temp reservations expire automatically after ~5 minutes.
+"""
+
+import logging
+import httpx
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+TABIT_API = "https://tgm-api.tabit.cloud"
+BRIDGE_API = "https://bridge.tabit.cloud"
+
+
+async def find_org_id(restaurant_name: str) -> Optional[str]:
+    """Search for a restaurant's Tabit org ID by name."""
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(
+                f"{BRIDGE_API}/organizations",
+                params={"name": restaurant_name, "limit": 5},
+                timeout=8,
+            )
+            orgs = resp.json()
+            if isinstance(orgs, list) and orgs:
+                return orgs[0].get("id")
+            return None
+        except Exception as e:
+            logger.warning(f"Tabit org lookup failed for {restaurant_name}: {e}")
+            return None
+
+
+async def get_booking_config(org_id: str) -> dict:
+    """
+    Get restaurant booking configuration — read-only, no side effects.
+    Returns booking_windows (scheduled hours by day-of-week), capacity, etc.
+    """
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(
+                f"{TABIT_API}/rsv/booking/configuration",
+                params={"organization": org_id},
+                timeout=8,
+            )
+            return resp.json()
+        except Exception as e:
+            logger.error(f"Tabit config fetch failed for {org_id}: {e}")
+            return {}
+
+
+async def check_availability(
+    org_id: str,
+    date: str,           # YYYY-MM-DD
+    time_str: str,       # HH:MM (24h)
+    party_size: int = 2,
+    restaurant_name: str = "",
+) -> dict:
+    """
+    Check real-time availability via temp reservation.
+    The temp reservation expires automatically after ~5 minutes.
+
+    Result format:
+    {
+        "available": bool,
+        "slots": [{"time": str, "area": str}],
+        "alternative_slots": [{"time": str}],
+        "booking_url": str | None,
+    }
+    """
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.post(
+                f"{TABIT_API}/rsv/booking/temp-reservations",
+                json={
+                    "organization": org_id,
+                    "date": date,
+                    "time": time_str,
+                    "seats": party_size,
+                },
+                timeout=10,
+            )
+            data = resp.json()
+        except Exception as e:
+            logger.error(f"Tabit availability check failed: {e}")
+            return {"available": False, "error": str(e), "slots": []}
+
+    # If we got a reservation ID — slot is available
+    reservation_id = data.get("id") or data.get("reservation_id")
+    available = bool(reservation_id)
+
+    # Delete temp reservation if created (cleanup, though it expires anyway)
+    if reservation_id:
+        try:
+            async with httpx.AsyncClient() as client2:
+                await client2.delete(
+                    f"{TABIT_API}/rsv/booking/temp-reservations/{reservation_id}",
+                    params={"organization": org_id},
+                    timeout=5,
+                )
+        except Exception:
+            pass  # Fine to ignore — it expires in 5 min anyway
+
+    # Parse alternative slots if main slot is taken
+    alt_slots = []
+    for alt in data.get("alternative_results", []):
+        t = alt.get("time", "")
+        alt_slots.append({"time": t})
+
+    return {
+        "available": available,
+        "slots": [{"time": time_str, "area": ""}] if available else [],
+        "alternative_slots": alt_slots,
+        "booking_url": None,  # Set by caller using restaurant-specific Tabit URL
+        "raw": data,
+    }

--- a/docs/chatbot-agent-prd.md
+++ b/docs/chatbot-agent-prd.md
@@ -1,0 +1,251 @@
+# PRD — Where2Eat Chatbot Agent
+
+**Status:** Ready for development
+**Author:** Boten (AI PM)
+**Last updated:** 2026-04-17
+
+---
+
+## Overview
+
+A conversational AI agent embedded in where2eat.rest that understands natural language requests, searches our restaurant database, checks real-time availability on Ontopo and Tabit, and recommends restaurants with live booking options.
+
+**Example interaction:**
+> "מחפש מסעדה לדייט באיזור תל אביב ביום חמישי בערב"
+> → Agent searches DB → checks real-time availability → returns 3 recommendations with available slots and direct booking links
+
+---
+
+## Channels
+
+| Channel | Status | Notes |
+|---------|--------|-------|
+| Website widget | MVP | Floating chat button on where2eat.rest |
+| Telegram bot | V2 | Separate bot, same backend API |
+| WhatsApp bot | V2 | Via Twilio or WhatsApp Business API |
+
+All channels share a single `/api/chat/message` backend endpoint.
+
+---
+
+## Architecture
+
+### Backend — FastAPI on Railway
+
+```
+User message
+    ↓
+POST /api/chat/message
+    ↓
+Claude Opus 4.6 (tool_use loop)
+    ↓
+Tools: search_db | check_ontopo | check_tabit | web_search
+    ↓
+Final response with availability + booking links
+```
+
+### Claude Agent — Python tool_use
+
+```python
+from anthropic import beta_tool, Anthropic
+
+client = Anthropic()  # ANTHROPIC_API_KEY from Railway env
+
+@beta_tool
+def search_restaurants(city: str, cuisine: str = "", occasion: str = "",
+                       price_range: str = "") -> str:
+    """חפש מסעדות ב-where2eat DB לפי עיר, סוג מטבח, אוקיישן ותקציב"""
+
+@beta_tool
+def check_ontopo(restaurant_name: str, ontopo_slug: str,
+                 date: str, time: str, party_size: int) -> str:
+    """בדוק זמינות מקומות ב-Ontopo (read-only, ללא יצירת הזמנה)"""
+
+@beta_tool
+def check_tabit(restaurant_name: str, tabit_org_id: str,
+                date: str, time: str, party_size: int) -> str:
+    """בדוק זמינות מקומות ב-Tabit (temp reservation, פוקע אחרי 5 דקות)"""
+
+runner = client.beta.messages.tool_runner(
+    model="claude-opus-4-6",
+    max_tokens=2048,
+    tools=[search_restaurants, check_ontopo, check_tabit],
+    system=SYSTEM_PROMPT,
+    messages=conversation_history,
+)
+```
+
+---
+
+## Availability Integrations
+
+### Ontopo ✅ (proven feasible)
+
+**API:** `https://ontopo.com/api/` (`.com`, not `.co.il` — no Cloudflare)
+**Auth:** Anonymous JWT — no account, no personal data required
+**Availability check:** Read-only, no reservation created
+
+```python
+# Step 1: Get token (expires ~15 min, cache it)
+token = requests.post("https://ontopo.com/api/loginAnonymously").json()["jwt_token"]
+
+# Step 2: Resolve slug (one-time per restaurant, store in DB)
+slug = requests.post("https://ontopo.com/api/slug_content",
+    json={"slug": "romano"}).json()["slug"]  # → "58551219"
+
+# Step 3: Check availability (pure read)
+result = requests.post("https://ontopo.com/api/availability_search",
+    headers={"token": token},
+    json={"slug": slug, "locale": "he",
+          "criteria": {"size": "2", "date": "20260421", "time": "2000"}})
+
+# Response includes:
+# - areas[].options[].method: "seat" = available, "standby" = waitlist, "disabled" = full
+# - areas[].options[].time: slot time (HHMM)
+# - recommended[]: top suggestions
+# - dates[]: alternative dates if requested date is full
+```
+
+**Response statuses:**
+- `method: "seat"` → available, bookable now
+- `method: "standby"` → waitlist only
+- `method: "disabled"` → fully booked
+- `dates[]` → alternative available dates
+
+**Booking link:** `https://ontopo.com/he/il/page/{slug}?date={YYYYMMDD}&time={HHMM}&size={N}`
+
+---
+
+### Tabit ✅ (proven feasible)
+
+**API:** `https://tgm-api.tabit.cloud/`
+**Auth:** None required for read operations
+**Availability check:** Via temp reservation (expires automatically after ~5 min)
+
+```python
+# Step 1: Get org config + booking windows (read-only, no side effects)
+config = requests.get(
+    "https://tgm-api.tabit.cloud/rsv/booking/configuration",
+    params={"organization": org_id}
+)
+# Returns booking_windows by day-of-week — use to show scheduled hours
+
+# Step 2: Check real availability (creates temp reservation, expires in 5 min)
+result = requests.post(
+    "https://tgm-api.tabit.cloud/rsv/booking/temp-reservations",
+    json={"organization": org_id, "date": date, "time": time, "seats": party_size}
+)
+# If slot taken → response includes alternative_results with nearby slots
+```
+
+**Restaurant lookup:** `GET https://bridge.tabit.cloud/organizations` (public, no auth)
+
+**Booking link:** Direct to restaurant's Tabit booking page
+
+---
+
+## System Prompt
+
+```
+אתה עוזר מסעדות חכם של where2eat.rest.
+
+יש לך גישה ל:
+- מסד נתונים של מסעדות מומלצות בישראל עם ביקורות ומידע מפודקאסטים
+- בדיקת זמינות אמיתית ב-Ontopo ו-Tabit
+
+הנחיות:
+1. הבן את הבקשה — עיר, תאריך/יום, מספר סועדים, אוקיישן, תקציב, סגנון
+2. חפש מסעדות מתאימות ב-DB
+3. לכל מסעדה רלוונטית — בדוק זמינות ב-Ontopo/Tabit
+4. הצג תוצאות ממוינות: קודם מאושרות (יש מקום), אחר כך ממתינות
+5. לכל מסעדה — כלול שעות פנויות + לינק הזמנה ישיר
+6. היה תמציתי, חם, וישיר — כמו חבר שמכיר את המסעדות
+
+פורמט תשובה:
+- מקסימום 3-4 מסעדות
+- לכל אחת: שם, תיאור קצר, שעות פנויות, לינק הזמנה
+- אם אין מקום — הצע תאריכים חלופיים
+```
+
+---
+
+## Data Model Changes
+
+### restaurants table — new fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ontopo_slug` | string | Numeric slug for Ontopo API (e.g. "58551219") |
+| `tabit_org_id` | string | Organization ID for Tabit API |
+| `booking_platforms` | json | `["ontopo", "tabit", "resy"]` |
+
+### conversations table (new)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | uuid | |
+| `session_id` | string | Browser session or Telegram chat ID |
+| `messages` | json | Full conversation history |
+| `created_at` | timestamp | |
+
+---
+
+## API Endpoint
+
+```
+POST /api/chat/message
+Body: {
+  "message": "מחפש מסעדה לדייט בתל אביב ביום חמישי",
+  "session_id": "uuid",
+  "history": [...],  // previous messages in this conversation
+  "context": {       // optional
+    "party_size": 2,
+    "date": "2026-04-24"
+  }
+}
+
+Response: {
+  "reply": "מצאתי 2 מסעדות פנויות...",
+  "session_id": "uuid",
+  "restaurants": [...]  // structured data for frontend to render cards
+}
+```
+
+---
+
+## Cost Estimate
+
+| Component | Est. Usage | Cost |
+|-----------|-----------|------|
+| Claude Opus 4.6 | ~20K tokens/conversation | ~$0.006/conversation |
+| Ontopo API | free | $0 |
+| Tabit API | free | $0 |
+| 100 conversations/day | | ~$0.60/day |
+| 1,000 conversations/day | | ~$6/day |
+
+---
+
+## MVP Scope
+
+**In:**
+- Website chat widget
+- Hebrew + English input
+- DB search + Ontopo availability check
+- Tabit availability check
+- Conversation history (within session)
+- Direct booking links
+
+**Out (V2):**
+- Telegram/WhatsApp bots
+- User accounts & saved preferences
+- Push notifications ("מקום התפנה ב-X")
+- Proactive recommendations ("בשבוע הבא יש לך ערב פנוי...")
+
+---
+
+## Open Questions
+
+1. Should we store `ontopo_slug` and `tabit_org_id` in the DB now, or resolve dynamically?
+2. Rate limits on Ontopo anonymous tokens — need to test at scale
+3. Tabit temp reservations — do they affect real availability? (5 min expiry should be fine)
+4. Widget placement — floating button or dedicated `/chat` page?

--- a/previews/ep125_preview.html
+++ b/previews/ep125_preview.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Episode Preview: 1tb-FUD5nMc</title>
+  <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;700;900&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Heebo', sans-serif; background: #FAFAF8; padding: 1rem; max-width: 480px; margin: 0 auto; }
+
+    .header { text-align: center; padding: 1.5rem 0; border-bottom: 1px solid #eee; margin-bottom: 1rem; }
+    .header h1 { font-size: 1.1rem; color: #333; }
+    .header .meta { font-size: 0.85rem; color: #888; margin-top: 0.25rem; }
+    .header .stats { display: flex; gap: 1rem; justify-content: center; margin-top: 0.75rem; font-size: 0.8rem; flex-wrap: wrap; }
+    .header .stat { background: #f0f0f0; padding: 0.25rem 0.75rem; border-radius: 999px; }
+    .header .stat.add { background: #E8F5E9; color: #2E7D32; }
+    .header .stat.skip { background: #FFF3E0; color: #E65100; }
+
+    .card { background: white; border-radius: 12px; overflow: hidden; margin-bottom: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    .card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.12); transition: all 0.2s; }
+
+    .card-image { width: 100%; aspect-ratio: 16/10; object-fit: cover; display: block; }
+    .card-image-fallback { width: 100%; aspect-ratio: 16/10; background: linear-gradient(135deg, #E63B2E, #FF6B5A); display: flex; align-items: center; justify-content: center; color: white; font-size: 1.5rem; font-weight: 700; }
+
+    .card-body { padding: 1rem; }
+    .card-title { font-size: 1.5rem; font-weight: 900; color: #1a1a1a; margin-bottom: 0.25rem; }
+    .card-meta { display: flex; gap: 0.5rem; align-items: center; color: #888; font-size: 0.85rem; margin-bottom: 0.5rem; flex-wrap: wrap; }
+    .card-meta .dot { color: #ccc; }
+    .card-date { font-size: 0.8rem; color: #999; margin-bottom: 0.5rem; }
+    .badge-new { background: #E63B2E; color: white; font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 4px; font-weight: 700; }
+
+    .card-quote { font-style: italic; background: #f5f5f5; padding: 0.75rem; border-radius: 8px; color: #555; font-size: 0.9rem; margin: 0.5rem 0; line-height: 1.6; }
+
+    .card-actions { display: flex; justify-content: space-between; align-items: center; border-top: 1px solid #f0f0f0; padding-top: 0.75rem; margin-top: 0.5rem; }
+    .rating { display: flex; align-items: center; gap: 0.25rem; font-weight: 700; color: #333; }
+    .rating .star { color: #FFB400; }
+    .timestamp-link { font-size: 0.8rem; color: #E63B2E; text-decoration: none; }
+    .timestamp-link:hover { text-decoration: underline; }
+
+    .verdict-badge { position: absolute; top: 0.5rem; left: 0.5rem; padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; }
+    .verdict-add { background: #E8F5E9; color: #2E7D32; }
+    .verdict-exists { background: #E3F2FD; color: #1565C0; }
+    .card-image-wrapper { position: relative; }
+
+    .section-title { font-size: 1rem; color: #888; margin: 1.5rem 0 0.75rem; padding-bottom: 0.25rem; border-bottom: 1px solid #eee; }
+
+    .ref-card { background: white; border-radius: 8px; padding: 0.75rem; margin-bottom: 0.5rem; border-right: 3px solid #FFB300; }
+    .ref-card .name { font-weight: 700; font-size: 0.95rem; }
+    .ref-card .reason { font-size: 0.8rem; color: #888; margin-top: 0.25rem; }
+    .ref-card .timestamp { font-size: 0.75rem; color: #E63B2E; margin-top: 0.25rem; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>עיניים על הבאגט | מדברים מהבטן, פרק 125</h1>
+    <div class="meta">מדברים מהבטן - הפודיום • 10 ספטמבר 2025</div>
+    <div class="stats">
+      <span class="stat add">✅ 4 מסעדות חדשות</span>
+      <span class="stat">📋 0 קיים</span>
+      <span class="stat skip">⏭️ 10 ייחוס בלבד</span>
+    </div>
+  </div>
+
+
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image" src="https://lh3.googleusercontent.com/places/ANXAkqF-JrWD-edBJiGht9Y73rQ-_gZH44zY1W9ztxmc5HJG6XSTHnEYkRaVgJTLN7Vx9l7x9784aHN" alt="ויני קולטורה" onerror="this.outerHTML='<div class=card-image-fallback>בר יין</div>'">
+      <span class="verdict-badge verdict-add">חדש</span>
+    </div>
+    <div class="card-body">
+      <div style="margin-bottom:0.25rem"><span style="background:#FF8C00;color:white;font-size:0.7rem;padding:0.1rem 0.4rem;border-radius:4px;font-weight:700;margin-right:0.5rem">נטעם</span></div>
+      <div class="card-title">ויני קולטורה</div>
+      <div class="card-meta">
+        <span>ראשון לציון</span><span class="dot">•</span>
+        <span>בר יין</span><span class="dot">•</span>
+        <span>₪₪</span>
+      </div>
+      <div class="card-date">📅 2025-09-10</div>
+      <div class="card-quote">"בר יין מקסים בראשון לציון, עיר שלא ידועה בורי היין שלה יותר מדי"</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.1 (60 ביקורות)</div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=169s" target="_blank">▶ 02:49</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image" src="https://lh3.googleusercontent.com/places/ANXAkqHS314bQ0NAKQUxvxWKw86rwEnAyGWLprbzg0IG1Pq7ghzyBFhUDichDSvD7CQ-K4FClcp99yQ" alt="בבוליה דלי" onerror="this.outerHTML='<div class=card-image-fallback>מעדנייה</div>'">
+      <span class="verdict-badge verdict-add">חדש</span>
+    </div>
+    <div class="card-body">
+      <div style="margin-bottom:0.25rem"><span style="background:#FF8C00;color:white;font-size:0.7rem;padding:0.1rem 0.4rem;border-radius:4px;font-weight:700;margin-right:0.5rem">נטעם</span></div>
+      <div class="card-title">בבוליה דלי</div>
+      <div class="card-meta">
+        <span>תל אביב</span><span class="dot">•</span>
+        <span>מעדנייה</span><span class="dot">•</span>
+        <span>₪₪₪</span>
+      </div>
+      <div class="card-date">📅 2025-09-10</div>
+      <div class="card-quote">"מדי פעם יש איזה מקום או איזה בן אדם שהם ההיפך הגמור והם נותנים זיק של תקווה ושל שפיות"</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.7 (48 ביקורות)</div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=721s" target="_blank">▶ 12:01</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image" src="https://lh3.googleusercontent.com/place-photos/AL8-SNEo9-Mc8EfzAu9c4zpMqYAOElFFAnMro06pUEj86g1vKGpQUa1tNAvVsS8O0j8sLrRZD" alt="שווארמה שמעוני" onerror="this.outerHTML='<div class=card-image-fallback>שווארמה</div>'">
+      <span class="verdict-badge verdict-add">חדש</span>
+    </div>
+    <div class="card-body">
+      <div style="margin-bottom:0.25rem"><span style="background:#FF8C00;color:white;font-size:0.7rem;padding:0.1rem 0.4rem;border-radius:4px;font-weight:700;margin-right:0.5rem">הוזכר</span></div>
+      <div class="card-title">שווארמה שמעוני</div>
+      <div class="card-meta">
+        <span>אשדוד</span><span class="dot">•</span>
+        <span>שווארמה</span><span class="dot">•</span>
+        <span>₪</span>
+      </div>
+      <div class="card-date">📅 2025-09-10</div>
+      <div class="card-quote">"נפתח בצומת, בצומת היציאה מאשדוד, המקום המופלא הזה שנקרא שווארמה שמעוני"</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 3.9 (108 ביקורות)</div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=453s" target="_blank">▶ 07:33</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image" src="https://lh3.googleusercontent.com/places/ANXAkqGtCA8gtkfEuuzspewL-ZE6ev-pQmR1BANh-Q2ltQEPQNh3UA8VqbfkGnv25FJJg0hdEDfqgxB" alt="פלט ביסטרו" onerror="this.outerHTML='<div class=card-image-fallback>ביסטרו צרפתי</div>'">
+      <span class="verdict-badge verdict-add">חדש</span>
+    </div>
+    <div class="card-body">
+      <div style="margin-bottom:0.25rem"><span style="background:#FF8C00;color:white;font-size:0.7rem;padding:0.1rem 0.4rem;border-radius:4px;font-weight:700;margin-right:0.5rem">נטעם</span></div>
+      <div class="card-title">פלט ביסטרו</div>
+      <div class="card-meta">
+        <span>תל אביב-יפו</span><span class="dot">•</span>
+        <span>ביסטרו צרפתי</span><span class="dot">•</span>
+        <span>₪₪₪</span>
+      </div>
+      <div class="card-date">📅 2025-09-10</div>
+      <div class="card-quote">"פלט הביסטרו שנפתח במלון בזאר ממש על סדרות ירושלים"</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.4 (490 ביקורות)</div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=792s" target="_blank">▶ 13:12</a>
+      </div>
+    </div>
+  </div>
+
+
+  <div class="section-title">⏭️ ייחוס בלבד</div>
+
+  <div class="ref-card">
+    <div class="name">קפה שילה</div>
+    <div class="reason">בעל המסעדה שרון כהן מוזמן לפרק כאורח לדבר על הפתיחה של קפה שילה - זה ידיעה עסקית ולא ביקורת</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=126s" target="_blank">▶ 02:06</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">ברנרד</div>
+    <div class="reason">אוזכר בקצרה בהקשר של ויני קולטורה בראשון לציון - ה'בית קפה של הכדורגלנים'. הזכרה אגבית.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=401s" target="_blank">▶ 06:41</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">פסקדו</div>
+    <div class="reason">הוזכר בהקשר של אשדוד בלילה - 'בפסקדו כבר לא תמצא שולחן'. הזכרה אגבית כחלק מסיפור על שווארמה שמעוני.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=444s" target="_blank">▶ 07:24</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">טבולה הרצליה</div>
+    <div class="reason">הוזכרה כהיסטוריה - 'המקום בהרצליה פיתוח שבמשך הרבה מאוד שנים היה מסעדת טבולה'. ייחוס היסטורי.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=2400s" target="_blank">▶ 40:00</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">ג'ורנו</div>
+    <div class="reason">הוזכר בהקשר של הרצליה מתעוררת - 'ג'ורנו כבודם במקומה מונח'. הזכרה אגבית.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=2460s" target="_blank">▶ 41:00</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">קאסה טואח</div>
+    <div class="reason">הוזכרה בהקשר של הרצליה מתעוררת - 'קאסה טואח, זה עוד לא שם'. לא נפתחה עדיין.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=2460s" target="_blank">▶ 41:00</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">אגאדיר</div>
+    <div class="reason">ידיעה תעשייתית - השקת קריספי צ'יקן חדש של שף תומר טל באגאדיר. לא ביקורת.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=2280s" target="_blank">▶ 38:00</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">לאקי צ'יקן</div>
+    <div class="reason">ייחוס היסטורי - 'שחר בועדנה שהיה מי שהקים בזמנו את לאקי צ'יקן'. הוזכר כרקע של מקים פלט ביסטרו.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=3180s" target="_blank">▶ 53:00</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">לונל</div>
+    <div class="reason">המגיש אמר 'לונל זאת המסעדה האהובה עליי שמעולם לא אכלתי בה עדיין'. לא נסקר.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=3480s" target="_blank">▶ 58:00</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">סזאר</div>
+    <div class="reason">ביקורת חיצונית - מביקורת של מבקר אחר (אבי אפרתי) שהוזכרה בפרק. לא הוסקרה על ידי המגישים.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1tb-FUD5nMc&t=3540s" target="_blank">▶ 59:00</a></div>
+  </div>
+
+
+</body>
+</html>

--- a/previews/ep126_preview.html
+++ b/previews/ep126_preview.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Episode Preview: 1s36GW9o6AQ — פרק 126</title>
+  <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;700;900&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Heebo', sans-serif; background: #FAFAF8; padding: 1rem; max-width: 480px; margin: 0 auto; }
+
+    .header { text-align: center; padding: 1.5rem 0; border-bottom: 1px solid #eee; margin-bottom: 1rem; }
+    .header h1 { font-size: 1.15rem; color: #333; font-weight: 700; }
+    .header .meta { font-size: 0.85rem; color: #888; margin-top: 0.25rem; }
+    .header .stats { display: flex; gap: 0.6rem; justify-content: center; margin-top: 0.75rem; font-size: 0.78rem; flex-wrap: wrap; }
+    .header .stat { background: #f0f0f0; padding: 0.25rem 0.75rem; border-radius: 999px; }
+    .header .stat.add { background: #E8F5E9; color: #2E7D32; }
+    .header .stat.skip { background: #FFF3E0; color: #E65100; }
+    .header .stat.exists { background: #E3F2FD; color: #1565C0; }
+
+    .card { background: white; border-radius: 12px; overflow: hidden; margin-bottom: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); transition: all 0.2s; }
+    .card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.12); }
+
+    .card-image { width: 100%; aspect-ratio: 16/10; object-fit: cover; display: block; }
+    .card-image-fallback { width: 100%; aspect-ratio: 16/10; background: linear-gradient(135deg, #E63B2E, #FF6B5A); display: flex; align-items: center; justify-content: center; color: white; font-size: 1.5rem; font-weight: 700; }
+
+    .card-body { padding: 1rem; }
+    .card-title { font-size: 1.4rem; font-weight: 900; color: #1a1a1a; margin-bottom: 0.25rem; }
+    .card-meta { display: flex; gap: 0.5rem; align-items: center; color: #888; font-size: 0.85rem; margin-bottom: 0.5rem; flex-wrap: wrap; }
+    .card-meta .dot { color: #ccc; }
+    .card-date { font-size: 0.8rem; color: #999; margin-bottom: 0.5rem; display: flex; align-items: center; gap: 0.25rem; }
+    .badge-new { background: #E63B2E; color: white; font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 4px; font-weight: 700; }
+    .badge-mention { background: #FFB300; color: white; font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 4px; font-weight: 700; margin-right: 4px; }
+    .badge-tasted { background: #FF6600; color: white; font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 4px; font-weight: 700; margin-right: 4px; }
+
+    .card-quote { font-style: italic; background: #f5f5f5; padding: 0.75rem; border-radius: 8px; color: #555; font-size: 0.9rem; margin: 0.5rem 0; line-height: 1.6; }
+
+    .card-actions { display: flex; justify-content: space-between; align-items: center; border-top: 1px solid #f0f0f0; padding-top: 0.75rem; margin-top: 0.5rem; }
+    .rating { display: flex; align-items: center; gap: 0.25rem; font-weight: 700; color: #333; }
+    .rating .star { color: #FFB400; }
+    .timestamp-link { font-size: 0.8rem; color: #E63B2E; text-decoration: none; }
+    .timestamp-link:hover { text-decoration: underline; }
+
+    .verdict-badge { position: absolute; top: 0.5rem; left: 0.5rem; padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.7rem; font-weight: 700; }
+    .verdict-add { background: #E8F5E9; color: #2E7D32; }
+    .verdict-exists { background: #E3F2FD; color: #1565C0; }
+    .card-image-wrapper { position: relative; }
+
+    .section-title { font-size: 1rem; color: #888; margin: 1.5rem 0 0.75rem; padding-bottom: 0.25rem; border-bottom: 1px solid #eee; }
+
+    .ref-card { background: white; border-radius: 8px; padding: 0.75rem; margin-bottom: 0.5rem; border-right: 3px solid #FFB300; }
+    .ref-card .name { font-weight: 700; font-size: 0.95rem; }
+    .ref-card .reason { font-size: 0.8rem; color: #888; margin-top: 0.25rem; }
+    .ref-card .timestamp { font-size: 0.75rem; color: #E63B2E; margin-top: 0.25rem; }
+
+    .note-box { background: #FFF8E1; border: 1px solid #FFE082; border-radius: 8px; padding: 0.75rem; margin-bottom: 1rem; font-size: 0.8rem; color: #795548; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1>מתחת לשולחן החג | מדברים מהבטן, פרק 126</h1>
+    <div class="meta">מדברים מהבטן - הפודיום • 17 בספטמבר 2025</div>
+    <div class="stats">
+      <span class="stat add">✅ 4 חדשים</span>
+      <span class="stat exists">📋 1 קיים</span>
+      <span class="stat skip">⏭️ 2 reference</span>
+    </div>
+  </div>
+
+  <div class="note-box">
+    ⚠️ Transcript לא זמין — YouTube חסמה גישה (הגנת בוט). חילוץ בוצע על בסיס תיאור הפרק מ-RSS. טיימסטמפים לא זמינים.
+  </div>
+
+  <!-- ADD TO PAGE cards -->
+
+  <!-- 1. קיו (נטעם) -->
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image"
+        src="https://lh3.googleusercontent.com/places/ANXAkqFLo7dWNec54TgPouwzv6ZG8uCyQpanmvfFS6PET2vB9oogaxgoC8N-JZrcW3k8bzj1HcZyB156baqsD_B7S-sH-xygHHPp5eY=s4800-w800"
+        alt="קיו"
+        onerror="this.outerHTML='<div class=card-image-fallback>בר-מסעדה</div>'">
+      <span class="verdict-badge verdict-add">NEW</span>
+    </div>
+    <div class="card-body">
+      <div class="card-title">קיו</div>
+      <div class="card-meta">
+        <span>תל אביב, לבונטין</span><span class="dot">•</span>
+        <span>בר-מסעדה</span><span class="dot">•</span>
+        <span>יקר</span>
+      </div>
+      <div class="card-date">📅 17 בספטמבר 2025</div>
+      <div class="card-date">
+        <span class="badge-tasted">נטעם</span>
+        שף בן כהן · הרכבת 12
+      </div>
+      <div class="card-quote">"יהונתן ביצע בקרת איכות ב'קיו'"</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.4 (201 ביקורות)</div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=1s36GW9o6AQ" target="_blank">▶ צפה בפרק</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2. צ'וטה (כבר קיים) -->
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image"
+        src="https://lh3.googleusercontent.com/places/ANXAkqE2MD7J0vQxyD4vEJd3WOVs-4Is8Z2smSvju3j59dgjDlAOxHxUm46JMMGX8CPY25a3_-Msj9KfgVvuBiItTZtoZ3bhsT-exiA=s4800-w800"
+        alt="צ'וטה"
+        onerror="this.outerHTML='<div class=card-image-fallback>שף</div>'">
+      <span class="verdict-badge verdict-exists">קיים</span>
+    </div>
+    <div class="card-body">
+      <div class="card-title">צ'וטה</div>
+      <div class="card-meta">
+        <span>ירושלים</span><span class="dot">•</span>
+        <span>שף</span><span class="dot">•</span>
+        <span>יקר</span>
+      </div>
+      <div class="card-date">📅 17 בספטמבר 2025 <span class="badge-new">חדש</span></div>
+      <div class="card-date">
+        <span class="badge-mention">הוזכר</span>
+        אילן גרוסי · בן סירא 18
+      </div>
+      <div class="card-quote">"שיחה עם האגדה הירושלמית אילן גרוסי על 'צ'וטה' החדשה שלו"</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.9 (87 ביקורות)</div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=1s36GW9o6AQ" target="_blank">▶ צפה בפרק</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3. ליבי פטיסרי -->
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image"
+        src="https://lh3.googleusercontent.com/places/ANXAkqH9Eg3FABNWK7_5sCwZAxP2XnDTq2dpLTnt8Ps0wgKHVtmORPIy6rgOfpS7Ul6F7f2G2et8PySSr_XJgO7L4yul5AYUFo5S6Zc=s4800-w800"
+        alt="קונדיטוריה ליבי"
+        onerror="this.outerHTML='<div class=card-image-fallback>פטיסרי</div>'">
+      <span class="verdict-badge verdict-add">NEW</span>
+    </div>
+    <div class="card-body">
+      <div class="card-title">קונדיטוריה ליבי</div>
+      <div class="card-meta">
+        <span>יקנעם המושבה</span><span class="dot">•</span>
+        <span>פטיסרי</span><span class="dot">•</span>
+        <span>בינוני</span>
+      </div>
+      <div class="card-date">📅 17 בספטמבר 2025</div>
+      <div class="card-date">
+        <span class="badge-mention">הוזכר</span>
+        כשר · אגרא יוקנעם
+      </div>
+      <div class="card-quote">"פטיסרי נהדר ביקנעם"</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.5 (510 ביקורות)</div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=1s36GW9o6AQ" target="_blank">▶ צפה בפרק</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- 4. BBANG BANG -->
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image"
+        src="https://lh3.googleusercontent.com/places/ANXAkqGrN8IbKgLPXK16DVGHD52e9P6P5ZunI6ruw73fVofQ1HtchMQvP1Z0-GgW7tVVKwtzApNtY9EB67GTI7aTyP-E9T2kdLb213A=s4800-w800"
+        alt="BBANG BANG בבנג בנג"
+        onerror="this.outerHTML='<div class=card-image-fallback>אסייתי</div>'">
+      <span class="verdict-badge verdict-add">NEW</span>
+    </div>
+    <div class="card-body">
+      <div class="card-title">BBANG BANG</div>
+      <div class="card-meta">
+        <span>תל אביב</span><span class="dot">•</span>
+        <span>אסייתי</span><span class="dot">•</span>
+        <span>בינוני</span>
+      </div>
+      <div class="card-date">📅 17 בספטמבר 2025</div>
+      <div class="card-date">
+        <span class="badge-mention">הוזכר</span>
+        קוריאני · אבן גבירול 138
+      </div>
+      <div class="card-quote">"אסייתית זריזה אך מוקפדת באבן גבירול"</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.3 (206 ביקורות)</div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=1s36GW9o6AQ" target="_blank">▶ צפה בפרק</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- 5. זלמנס עזריאלי -->
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image"
+        src="https://lh3.googleusercontent.com/place-photos/AL8-SNGS0FcY5JrXognfSw7TatTqJ-xBWkKz9031E0rW2bgXe5W01Q26cgtv80OW1vSDATSaJWhoVmkjB4829X0u-zMuLBEQtEpyPHsIUIpSPjdWpLHJfN-cD66YFXAHAsNqssdBaMsmrsagNfEV=s4800-w800"
+        alt="זלמנס עזריאלי"
+        onerror="this.outerHTML='<div class=card-image-fallback>נקניקיות</div>'">
+      <span class="verdict-badge verdict-add">NEW</span>
+    </div>
+    <div class="card-body">
+      <div class="card-title">זלמנס עזריאלי</div>
+      <div class="card-meta">
+        <span>תל אביב, עזריאלי</span><span class="dot">•</span>
+        <span>נקניקיות</span><span class="dot">•</span>
+        <span>זול</span>
+      </div>
+      <div class="card-date">📅 17 בספטמבר 2025</div>
+      <div class="card-date">
+        <span class="badge-mention">הוזכר</span>
+        כשר · קניון עזריאלי
+      </div>
+      <div class="card-quote">"נקניקיה מפתיעה בעזריאלי"</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.0 (42 ביקורות)</div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=1s36GW9o6AQ" target="_blank">▶ צפה בפרק</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- REFERENCE ONLY section -->
+  <div class="section-title">⏭️ Reference Only</div>
+
+  <div class="ref-card">
+    <div class="name">קפיצה קולינרית של קריית אונו (topic)</div>
+    <div class="reason">דיון כללי על תחייה קולינרית באזור – לא מסעדה ספציפית</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1s36GW9o6AQ" target="_blank">▶ צפה בפרק</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="name">צ'לו (Chelo) — ירושלים</div>
+    <div class="reason">הפניה היסטורית — מסעדה שפעלה 1991-2021 לפני צ'וטה. סגורה.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=1s36GW9o6AQ" target="_blank">▶ צפה בפרק</a></div>
+  </div>
+
+</body>
+</html>

--- a/previews/ep127_preview.html
+++ b/previews/ep127_preview.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Episode Preview: פרק 127 — בסוכה עם שף תומר אגאי</title>
+  <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;700;900&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Heebo', sans-serif; background: #FAFAF8; padding: 1rem; max-width: 480px; margin: 0 auto; }
+
+    .header { text-align: center; padding: 1.5rem 0; border-bottom: 1px solid #eee; margin-bottom: 1rem; }
+    .header h1 { font-size: 1.15rem; color: #1a1a1a; font-weight: 900; line-height: 1.4; }
+    .header .meta { font-size: 0.82rem; color: #888; margin-top: 0.35rem; }
+    .header .stats { display: flex; gap: 0.6rem; justify-content: center; margin-top: 0.85rem; font-size: 0.78rem; flex-wrap: wrap; }
+    .header .stat { background: #f0f0f0; padding: 0.25rem 0.75rem; border-radius: 999px; }
+    .header .stat.add { background: #E8F5E9; color: #2E7D32; }
+    .header .stat.skip { background: #FFF3E0; color: #E65100; }
+    .header .stat.warn { background: #FFF9C4; color: #F57F17; font-size: 0.72rem; padding: 0.2rem 0.6rem; }
+
+    .section-title { font-size: 0.9rem; color: #888; margin: 1.5rem 0 0.75rem; padding-bottom: 0.25rem; border-bottom: 1px solid #eee; font-weight: 700; }
+
+    .card { background: white; border-radius: 12px; overflow: hidden; margin-bottom: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.08); transition: all 0.2s; }
+    .card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.12); }
+
+    .card-image { width: 100%; aspect-ratio: 16/10; object-fit: cover; display: block; }
+    .card-image-fallback { width: 100%; aspect-ratio: 16/10; background: linear-gradient(135deg, #E63B2E, #FF6B5A); display: flex; align-items: center; justify-content: center; color: white; font-size: 1.4rem; font-weight: 700; text-align: center; padding: 1rem; }
+
+    .card-image-wrapper { position: relative; }
+
+    .verdict-badge { position: absolute; top: 0.5rem; left: 0.5rem; padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.68rem; font-weight: 700; }
+    .verdict-new { background: #E63B2E; color: white; }
+    .verdict-exists { background: #1565C0; color: white; }
+
+    .mention-badge { position: absolute; top: 0.5rem; right: 0.5rem; padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.68rem; font-weight: 700; }
+    .badge-natam { background: #FF8C00; color: white; }
+    .badge-huzkar { background: #666; color: white; }
+
+    .card-body { padding: 1rem; }
+    .card-title { font-size: 1.45rem; font-weight: 900; color: #1a1a1a; margin-bottom: 0.2rem; }
+    .card-meta { display: flex; gap: 0.4rem; align-items: center; color: #888; font-size: 0.82rem; margin-bottom: 0.4rem; flex-wrap: wrap; }
+    .card-meta .dot { color: #ccc; }
+    .card-date { font-size: 0.76rem; color: #999; margin-bottom: 0.5rem; display: flex; align-items: center; gap: 0.3rem; }
+
+    .card-quote { font-style: italic; background: #f5f5f5; padding: 0.65rem 0.75rem; border-radius: 8px; color: #555; font-size: 0.88rem; margin: 0.5rem 0; line-height: 1.55; border-right: 3px solid #E63B2E; }
+
+    .card-actions { display: flex; justify-content: space-between; align-items: center; border-top: 1px solid #f0f0f0; padding-top: 0.65rem; margin-top: 0.5rem; }
+    .rating { display: flex; align-items: center; gap: 0.25rem; font-weight: 700; color: #333; font-size: 0.9rem; }
+    .rating .star { color: #FFB400; }
+    .timestamp-link { font-size: 0.78rem; color: #E63B2E; text-decoration: none; display: flex; align-items: center; gap: 0.2rem; }
+    .timestamp-link:hover { text-decoration: underline; }
+
+    .ref-card { background: white; border-radius: 8px; padding: 0.75rem 1rem; margin-bottom: 0.5rem; border-right: 3px solid #FFB300; }
+    .ref-card .ref-header { display: flex; justify-content: space-between; align-items: flex-start; }
+    .ref-card .name { font-weight: 700; font-size: 0.95rem; color: #1a1a1a; }
+    .ref-card .city-tag { font-size: 0.75rem; color: #888; margin-top: 0.1rem; }
+    .ref-card .reason { font-size: 0.8rem; color: #999; margin-top: 0.35rem; font-style: italic; }
+    .ref-card .timestamp { font-size: 0.72rem; color: #E63B2E; margin-top: 0.2rem; }
+    .ref-card .rating-small { font-size: 0.78rem; color: #555; font-weight: 700; }
+    .ref-card .star-small { color: #FFB400; font-size: 0.75rem; }
+
+    .warning-box { background: #FFF9C4; border: 1px solid #F9A825; border-radius: 8px; padding: 0.75rem 1rem; margin: 1rem 0; font-size: 0.8rem; color: #5D4037; line-height: 1.5; }
+    .warning-box strong { color: #E65100; }
+  </style>
+</head>
+<body>
+
+  <div class="header">
+    <h1>בסוכה עם שף תומר אגאי</h1>
+    <div class="meta">מדברים מהבטן — פרק 127 &nbsp;•&nbsp; 25 ספטמבר 2025</div>
+    <div class="stats">
+      <span class="stat add">✅ 3 להוסיף</span>
+      <span class="stat">📋 2 כבר קיימות</span>
+      <span class="stat skip">⏭️ 3 רפרנס בלבד</span>
+      <span class="stat warn">⚠️ טיימסטמפים משוערים</span>
+    </div>
+  </div>
+
+  <div class="warning-box">
+    <strong>שים לב:</strong> הטרנסקריפט המלא לא היה זמין (IP block של YouTube). הנתונים עוברו ממקורות משניים (כתבות, RSS). טיימסטמפים הם <strong>הערכות</strong> בלבד ולא ניתן לאמת אותם ללא הטרנסקריפט.
+  </div>
+
+  <!-- ADD TO PAGE section -->
+  <div class="section-title">✅ להוסיף לדף (3 מסעדות)</div>
+
+  <!-- Card 1: Alena — already in DB -->
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image"
+        src="https://lh3.googleusercontent.com/places/ANXAkqE_AHDzRC888A3M1snxnJEejOyKUnkqnBWwEVtIdThj_nsrrv-70n0JyxxmFd2kqylP2F45EOv8pzv6Yu1fyIjmiQeEo8VPmQ=s4800-w675"
+        alt="אלנה"
+        onerror="this.outerHTML='<div class=card-image-fallback>ים תיכוני</div>'">
+      <span class="verdict-badge verdict-exists">קיימת ב-DB</span>
+      <span class="mention-badge badge-natam">נטעם</span>
+    </div>
+    <div class="card-body">
+      <div class="card-title">אלנה</div>
+      <div class="card-meta">
+        <span>תל אביב</span>
+        <span class="dot">•</span>
+        <span>ים תיכוני</span>
+        <span class="dot">•</span>
+        <span>יקר</span>
+      </div>
+      <div class="card-date">📅 25.09.2025 &nbsp;•&nbsp; <span>נטע סלונים</span></div>
+      <div class="card-quote">ארוחה רומנטית מלאה במסעדת אלנה שבמלון הנורמן</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.1 <span style="color:#aaa;font-size:0.78rem">(1,095 ביקורות)</span></div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=8fKi1aA24-w&t=600s" target="_blank">▶ ~10:00 ⚠️</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- Card 2: Thai Chu — already in DB -->
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image"
+        src="https://lh3.googleusercontent.com/places/ANXAkqF_0iKd0RW60_NQYsDvKpjzMfBbj0oCV1pKt9zar25dSnY6-RdhfXxDZPeG7o16Tb9sWkViRGqwMwUxWRqQShSweKGv_MmPYtU=s4800-w800"
+        alt="תאי צ'ו"
+        onerror="this.outerHTML='<div class=card-image-fallback>תאילנדי</div>'">
+      <span class="verdict-badge verdict-exists">קיימת ב-DB</span>
+      <span class="mention-badge badge-natam">נטעם</span>
+    </div>
+    <div class="card-body">
+      <div class="card-title">תאי צ'ו</div>
+      <div class="card-meta">
+        <span>פתח תקווה</span>
+        <span class="dot">•</span>
+        <span>תאילנדי</span>
+        <span class="dot">•</span>
+        <span>בינוני</span>
+      </div>
+      <div class="card-date">📅 25.09.2025 &nbsp;•&nbsp; <span>עמית אהרונסון</span></div>
+      <div class="card-quote">עמית הופתע לטובה — מסעדה תאילנדית אותנטית ומקורית בפתח תקווה</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.6 <span style="color:#aaa;font-size:0.78rem">(271 ביקורות)</span></div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=8fKi1aA24-w&t=1200s" target="_blank">▶ ~20:00 ⚠️</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- Card 3: Bel Ami — NEW -->
+  <div class="card">
+    <div class="card-image-wrapper">
+      <img class="card-image"
+        src="https://lh3.googleusercontent.com/places/ANXAkqE2iSXVMdvNQUrt24lqsvlqjfkloQ3ddl_oZb2X90JqWbifS6xaOxUoxFkJSQROfzyZpuFDqSi1HDUhbTC8jB6Yp3huv8yGNug=s4800-w800"
+        alt="בל עמי"
+        onerror="this.outerHTML='<div class=card-image-fallback>צרפתי</div>'">
+      <span class="verdict-badge verdict-new">חדש!</span>
+      <span class="mention-badge badge-natam">נטעם</span>
+    </div>
+    <div class="card-body">
+      <div class="card-title">בל עמי</div>
+      <div class="card-meta">
+        <span>תל אביב</span>
+        <span class="dot">•</span>
+        <span>צרפתי</span>
+        <span class="dot">•</span>
+        <span>יקר</span>
+      </div>
+      <div class="card-date">📅 25.09.2025 &nbsp;•&nbsp; <span>עמית אהרונסון</span></div>
+      <div class="card-quote">ברסרי צרפתי חדש שכבר הוכיח שהבאזז מוצדק — עמית ממליץ בחום</div>
+      <div class="card-actions">
+        <div class="rating"><span class="star">★</span> 4.1 <span style="color:#aaa;font-size:0.78rem">(155 ביקורות)</span></div>
+        <a class="timestamp-link" href="https://www.youtube.com/watch?v=8fKi1aA24-w&t=1800s" target="_blank">▶ ~30:00 ⚠️</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- REFERENCE ONLY section -->
+  <div class="section-title">⏭️ רפרנס בלבד (3 מסעדות)</div>
+
+  <div class="ref-card">
+    <div class="ref-header">
+      <div>
+        <div class="name">סנטה קתרינה</div>
+        <div class="city-tag">הר סיני 2, תל אביב</div>
+      </div>
+      <div class="rating-small"><span class="star-small">★</span> 4.2</div>
+    </div>
+    <div class="reason">בעל המסעדה מנתח את כישלונה — ניתוח עסקי, לא המלצת ביקור. המסעדה נסגרה.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=8fKi1aA24-w&t=2400s" target="_blank" style="color:#E63B2E;text-decoration:none">▶ ~40:00 ⚠️</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="ref-header">
+      <div>
+        <div class="name">מאזה</div>
+        <div class="city-tag">נחלת בנימין 45, תל אביב</div>
+      </div>
+      <div class="rating-small"><span class="star-small">★</span> 4.1</div>
+    </div>
+    <div class="reason">תומר אגאי חושף שמו מופיע על המקום אבל הוא לא מבשל שם ביומיום — חשיפה עסקית.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=8fKi1aA24-w&t=3000s" target="_blank" style="color:#E63B2E;text-decoration:none">▶ ~50:00 ⚠️</a></div>
+  </div>
+
+  <div class="ref-card">
+    <div class="ref-header">
+      <div>
+        <div class="name">O</div>
+        <div class="city-tag">שדרות רוטשילד 45, תל אביב</div>
+      </div>
+      <div class="rating-small"><span class="star-small">★</span> 4.1</div>
+    </div>
+    <div class="reason">הוכרז בפרק כ"מקום החדש שבדרך" — נפתח רק בדצמבר 2025. בעת ההקלטה לא היה קיים.</div>
+    <div class="timestamp"><a href="https://www.youtube.com/watch?v=8fKi1aA24-w&t=3300s" target="_blank" style="color:#E63B2E;text-decoration:none">▶ ~55:00 ⚠️</a></div>
+  </div>
+
+  <div style="text-align:center; font-size:0.72rem; color:#aaa; margin-top:2rem; padding-top:1rem; border-top:1px solid #eee;">
+    Generated by episode-processor · 2026-04-08<br>
+    ⚠️ Timestamps are estimated (transcript unavailable)
+  </div>
+
+</body>
+</html>

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -1,0 +1,479 @@
+"""
+Tests for the chat agent endpoint and services.
+
+Covers:
+- Ontopo service: token caching, availability parsing
+- Tabit service: availability check, cleanup
+- Chat router: tool dispatch, agentic loop, fallback
+"""
+
+import json
+import sys
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+# Add api/ to path so we can import the modules directly
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(PROJECT_ROOT, "api"))
+
+
+# ---------------------------------------------------------------------------
+# Ontopo service tests
+# ---------------------------------------------------------------------------
+
+class TestOntopoService:
+    """Unit tests for api/services/ontopo.py"""
+
+    @pytest.mark.asyncio
+    async def test_get_token_fetches_and_caches(self):
+        """Token is fetched once and cached for subsequent calls."""
+        from services import ontopo
+        # Reset cache
+        ontopo._token_cache["token"] = None
+        ontopo._token_cache["expires_at"] = 0
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"jwt_token": "test-jwt-123"}
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        token = await ontopo._get_token(mock_client)
+        assert token == "test-jwt-123"
+        assert ontopo._token_cache["token"] == "test-jwt-123"
+        mock_client.post.assert_called_once()
+
+        # Second call — should NOT call API again (cached)
+        token2 = await ontopo._get_token(mock_client)
+        assert token2 == "test-jwt-123"
+        mock_client.post.assert_called_once()  # still once
+
+    @pytest.mark.asyncio
+    async def test_check_availability_returns_available_when_seat_slots(self):
+        """Returns available=True when seat slots exist."""
+        from services import ontopo
+        ontopo._token_cache["token"] = "cached-token"
+        ontopo._token_cache["expires_at"] = 9999999999
+
+        api_response = {
+            "areas": [
+                {
+                    "name": "חוץ",
+                    "options": [
+                        {"method": "seat", "time": "2000"},
+                        {"method": "seat", "time": "2030"},
+                        {"method": "disabled", "time": "1930"},
+                    ],
+                }
+            ],
+            "recommended": [{"method": "seat", "time": "2000", "id": "outdoor"}],
+            "dates": [],
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = api_response
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_cls.return_value = mock_client
+
+            result = await ontopo.check_availability("58551219", "20260421", "2000", 2)
+
+        assert result["available"] is True
+        assert len(result["slots"]) == 2
+        assert result["slots"][0]["time"] == "20:00"
+        assert result["booking_url"] == "https://ontopo.com/he/il/page/58551219?date=20260421&time=2000&size=2"
+
+    @pytest.mark.asyncio
+    async def test_check_availability_returns_not_available_when_no_seat_slots(self):
+        """Returns available=False when all slots are disabled/standby."""
+        from services import ontopo
+        ontopo._token_cache["token"] = "cached-token"
+        ontopo._token_cache["expires_at"] = 9999999999
+
+        api_response = {
+            "areas": [
+                {
+                    "name": "פנים",
+                    "options": [
+                        {"method": "disabled", "time": "2000"},
+                        {"method": "standby", "time": "2030"},
+                    ],
+                }
+            ],
+            "recommended": [],
+            "dates": ["202604221900"],
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = api_response
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_cls.return_value = mock_client
+
+            result = await ontopo.check_availability("58551219", "20260421", "2000", 2)
+
+        assert result["available"] is False
+        assert result["slots"] == []
+        assert len(result["alternative_dates"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_check_availability_handles_api_error(self):
+        """Returns error dict on API failure."""
+        from services import ontopo
+        ontopo._token_cache["token"] = "cached-token"
+        ontopo._token_cache["expires_at"] = 9999999999
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=Exception("timeout"))
+            mock_cls.return_value = mock_client
+
+            result = await ontopo.check_availability("999", "20260421", "2000", 2)
+
+        assert result["available"] is False
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Tabit service tests
+# ---------------------------------------------------------------------------
+
+class TestTabitService:
+    """Unit tests for api/services/tabit.py"""
+
+    @pytest.mark.asyncio
+    async def test_check_availability_returns_true_when_reservation_created(self):
+        """Returns available=True when temp reservation ID returned."""
+        from services import tabit
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"id": "tmp-res-abc123", "alternative_results": []}
+
+        mock_del_resp = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_client.delete = AsyncMock(return_value=mock_del_resp)
+            mock_cls.return_value = mock_client
+
+            result = await tabit.check_availability("org-123", "2026-04-21", "20:00", 2)
+
+        assert result["available"] is True
+        assert len(result["slots"]) == 1
+        assert result["slots"][0]["time"] == "20:00"
+
+    @pytest.mark.asyncio
+    async def test_check_availability_returns_false_when_no_reservation_id(self):
+        """Returns available=False when no reservation ID (slot taken)."""
+        from services import tabit
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "alternative_results": [{"time": "20:30"}, {"time": "21:00"}]
+        }
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=mock_resp)
+            mock_cls.return_value = mock_client
+
+            result = await tabit.check_availability("org-123", "2026-04-21", "20:00", 2)
+
+        assert result["available"] is False
+        assert result["slots"] == []
+        assert len(result["alternative_slots"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_check_availability_handles_exception(self):
+        """Returns error dict on network failure."""
+        from services import tabit
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=Exception("connection refused"))
+            mock_cls.return_value = mock_client
+
+            result = await tabit.check_availability("org-456", "2026-04-21", "20:00", 2)
+
+        assert result["available"] is False
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Chat router tool handler tests
+# ---------------------------------------------------------------------------
+
+def _import_chat():
+    """Import chat module directly, bypassing routers/__init__.py to avoid jose dep."""
+    import importlib.util, pathlib
+    spec = importlib.util.spec_from_file_location(
+        "chat",
+        pathlib.Path(PROJECT_ROOT) / "api" / "routers" / "chat.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestChatToolHandlers:
+    """Unit tests for tool handler functions in routers/chat.py"""
+
+    @pytest.mark.asyncio
+    async def test_search_restaurants_returns_json(self):
+        """_tool_search_restaurants returns valid JSON with restaurant list."""
+        chat = _import_chat()
+        _tool_search_restaurants = chat._tool_search_restaurants
+
+        mock_data = {
+            "restaurants": [
+                {
+                    "id": "1",
+                    "name_hebrew": "רומנו",
+                    "name_english": "Romano",
+                    "city": "תל אביב",
+                    "cuisine_type": "איטלקי",
+                    "google_rating": 4.5,
+                    "description": "מסעדה איטלקית",
+                    "ontopo_slug": "58551219",
+                    "tabit_org_id": None,
+                    "address": "רחוב הרצל 1",
+                }
+            ]
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = mock_data
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_resp)
+            mock_cls.return_value = mock_client
+
+            result = await _tool_search_restaurants(city="תל אביב", cuisine="איטלקי")
+
+        data = json.loads(result)
+        assert isinstance(data, list)
+        assert data[0]["name_hebrew"] == "רומנו"
+        assert data[0]["ontopo_slug"] == "58551219"
+
+    @pytest.mark.asyncio
+    async def test_search_restaurants_handles_error(self):
+        """_tool_search_restaurants returns error JSON on failure."""
+        _tool_search_restaurants = _import_chat()._tool_search_restaurants
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(side_effect=Exception("API down"))
+            mock_cls.return_value = mock_client
+
+            result = await _tool_search_restaurants(city="תל אביב")
+
+        data = json.loads(result)
+        assert "error" in data
+
+    @pytest.mark.asyncio
+    async def test_tool_check_ontopo_formats_date_and_time(self):
+        """_tool_check_ontopo strips dashes and colons before calling service."""
+        _tool_check_ontopo = _import_chat()._tool_check_ontopo
+
+        with patch("services.ontopo.check_availability") as mock_check:
+            mock_check.return_value = {
+                "available": True,
+                "slots": [{"time": "20:00", "area": "חוץ"}],
+                "recommended": [],
+                "alternative_dates": [],
+                "booking_url": "https://ontopo.com/he/il/page/123",
+            }
+
+            result = await _tool_check_ontopo(
+                ontopo_slug="123",
+                date="2026-04-21",
+                time="20:00",
+                party_size=2,
+            )
+
+        # Check service was called with stripped formats
+        mock_check.assert_called_once_with(
+            numeric_slug="123",
+            date="20260421",
+            time_str="2000",
+            party_size=2,
+        )
+        data = json.loads(result)
+        assert data["available"] is True
+
+    @pytest.mark.asyncio
+    async def test_tool_check_tabit_passes_correct_params(self):
+        """_tool_check_tabit passes org_id and datetime correctly."""
+        _tool_check_tabit = _import_chat()._tool_check_tabit
+
+        with patch("services.tabit.check_availability") as mock_check:
+            mock_check.return_value = {
+                "available": False,
+                "slots": [],
+                "alternative_slots": [{"time": "21:00"}],
+            }
+
+            result = await _tool_check_tabit(
+                tabit_org_id="org-abc",
+                date="2026-04-21",
+                time="20:00",
+                party_size=4,
+            )
+
+        mock_check.assert_called_once_with(
+            org_id="org-abc",
+            date="2026-04-21",
+            time_str="20:00",
+            party_size=4,
+        )
+        data = json.loads(result)
+        assert data["available"] is False
+        assert len(data["alternative_slots"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Chat endpoint integration tests
+# ---------------------------------------------------------------------------
+
+class TestChatEndpoint:
+    """Integration tests for POST /api/chat/message"""
+
+    @pytest.mark.asyncio
+    async def test_endpoint_returns_reply_on_end_turn(self):
+        """Endpoint returns reply text when Claude stops with end_turn."""
+        from fastapi.testclient import TestClient
+        from fastapi import FastAPI
+        chat_module = _import_chat()
+
+        # Minimal FastAPI app with just the chat router
+        test_app = FastAPI()
+        test_app.include_router(chat_module.router)
+
+        # Build a mock Claude response with end_turn
+        mock_content_block = MagicMock()
+        mock_content_block.type = "text"
+        mock_content_block.text = "הנה שלוש מסעדות מומלצות..."
+
+        mock_response = MagicMock()
+        mock_response.stop_reason = "end_turn"
+        mock_response.content = [mock_content_block]
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test-key"}):
+            with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+                mock_client = AsyncMock()
+                mock_client.messages.create = AsyncMock(return_value=mock_response)
+                mock_anthropic_cls.return_value = mock_client
+
+                with TestClient(test_app) as client:
+                    resp = client.post(
+                        "/api/chat/message",
+                        json={
+                            "message": "מחפש מסעדה לדייט בתל אביב",
+                            "session_id": "test-session",
+                            "history": [],
+                        },
+                    )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["reply"] == "הנה שלוש מסעדות מומלצות..."
+        assert data["session_id"] == "test-session"
+
+    @pytest.mark.asyncio
+    async def test_endpoint_executes_tool_and_returns_final_reply(self):
+        """Endpoint calls tool handler and loops back to get final reply."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        chat_module = _import_chat()
+
+        test_app = FastAPI()
+        test_app.include_router(chat_module.router)
+
+        # First response: tool_use
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.name = "search_restaurants"
+        tool_block.id = "tool-1"
+        tool_block.input = {"city": "תל אביב", "cuisine": "איטלקי"}
+
+        response_turn1 = MagicMock()
+        response_turn1.stop_reason = "tool_use"
+        response_turn1.content = [tool_block]
+
+        # Second response: end_turn
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = "מצאתי מסעדות מעולות!"
+
+        response_turn2 = MagicMock()
+        response_turn2.stop_reason = "end_turn"
+        response_turn2.content = [text_block]
+
+        # Mock tool handler
+        mock_tool_result = json.dumps([{"name_hebrew": "טסטו", "city": "תל אביב"}])
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test-key"}):
+            with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
+                mock_client = AsyncMock()
+                mock_client.messages.create = AsyncMock(
+                    side_effect=[response_turn1, response_turn2]
+                )
+                mock_anthropic_cls.return_value = mock_client
+
+                with patch.dict(
+                    chat_module.TOOL_HANDLERS,
+                    {"search_restaurants": AsyncMock(return_value=mock_tool_result)},
+                ):
+                    with TestClient(test_app) as client:
+                        resp = client.post(
+                            "/api/chat/message",
+                            json={"message": "מסעדה איטלקית בתל אביב", "history": []},
+                        )
+
+        assert resp.status_code == 200
+        assert resp.json()["reply"] == "מצאתי מסעדות מעולות!"
+        assert mock_client.messages.create.call_count == 2
+
+    def test_endpoint_returns_500_without_api_key(self):
+        """Returns 500 when ANTHROPIC_API_KEY is missing."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        chat_module = _import_chat()
+
+        test_app = FastAPI()
+        test_app.include_router(chat_module.router)
+
+        env_without_key = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+        with patch.dict(os.environ, env_without_key, clear=True):
+            with TestClient(test_app) as client:
+                resp = client.post(
+                    "/api/chat/message",
+                    json={"message": "שלום", "history": []},
+                )
+
+        assert resp.status_code == 500
+        assert "ANTHROPIC_API_KEY" in resp.json()["detail"]

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -1,125 +1,114 @@
 """
 Tests for the chat agent endpoint and services.
 
-Covers:
-- Ontopo service: token caching, availability parsing
-- Tabit service: availability check, cleanup
-- Chat router: tool dispatch, agentic loop, fallback
+Covers: Ontopo service, Tabit service, chat router tool dispatch and agentic loop.
 """
 
 import json
-import sys
 import os
+import sys
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-# Add api/ to path so we can import the modules directly
 PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(PROJECT_ROOT, "api"))
 
 
 # ---------------------------------------------------------------------------
-# Ontopo service tests
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_httpx_client(post=None, get=None, delete=None):
+    """Return a patched httpx.AsyncClient context manager."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    if post is not None:
+        mock_client.post = AsyncMock(return_value=post)
+    if get is not None:
+        mock_client.get = AsyncMock(return_value=get)
+    if delete is not None:
+        mock_client.delete = AsyncMock(return_value=delete)
+    return mock_client
+
+
+def _json_resp(data):
+    resp = MagicMock()
+    resp.json.return_value = data
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _import_chat():
+    import importlib.util, pathlib
+    spec = importlib.util.spec_from_file_location(
+        "chat", pathlib.Path(PROJECT_ROOT) / "api" / "routers" / "chat.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Ontopo service
 # ---------------------------------------------------------------------------
 
 class TestOntopoService:
-    """Unit tests for api/services/ontopo.py"""
-
-    @pytest.mark.asyncio
-    async def test_get_token_fetches_and_caches(self):
-        """Token is fetched once and cached for subsequent calls."""
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
         from services import ontopo
-        # Reset cache
         ontopo._token_cache["token"] = None
         ontopo._token_cache["expires_at"] = 0
 
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"jwt_token": "test-jwt-123"}
-        mock_resp.raise_for_status = MagicMock()
-
+    @pytest.mark.asyncio
+    async def test_get_token_fetches_and_caches(self):
+        from services import ontopo
         mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.post = AsyncMock(return_value=_json_resp({"jwt_token": "tok-123"}))
 
         token = await ontopo._get_token(mock_client)
-        assert token == "test-jwt-123"
-        assert ontopo._token_cache["token"] == "test-jwt-123"
+        assert token == "tok-123"
+        assert ontopo._token_cache["token"] == "tok-123"
+
+        # Second call — must NOT hit API again
+        await ontopo._get_token(mock_client)
         mock_client.post.assert_called_once()
 
-        # Second call — should NOT call API again (cached)
-        token2 = await ontopo._get_token(mock_client)
-        assert token2 == "test-jwt-123"
-        mock_client.post.assert_called_once()  # still once
-
     @pytest.mark.asyncio
-    async def test_check_availability_returns_available_when_seat_slots(self):
-        """Returns available=True when seat slots exist."""
+    async def test_check_availability_returns_available(self):
         from services import ontopo
-        ontopo._token_cache["token"] = "cached-token"
-        ontopo._token_cache["expires_at"] = 9999999999
+        ontopo._token_cache.update({"token": "t", "expires_at": 9_999_999_999})
 
-        api_response = {
-            "areas": [
-                {
-                    "name": "חוץ",
-                    "options": [
-                        {"method": "seat", "time": "2000"},
-                        {"method": "seat", "time": "2030"},
-                        {"method": "disabled", "time": "1930"},
-                    ],
-                }
-            ],
+        api_resp = {
+            "areas": [{"name": "חוץ", "options": [
+                {"method": "seat", "time": "2000"},
+                {"method": "seat", "time": "2030"},
+                {"method": "disabled", "time": "1930"},
+            ]}],
             "recommended": [{"method": "seat", "time": "2000", "id": "outdoor"}],
             "dates": [],
         }
-
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = api_response
-
-        with patch("httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(return_value=mock_resp)
-            mock_cls.return_value = mock_client
-
+        with patch("httpx.AsyncClient", return_value=_mock_httpx_client(post=_json_resp(api_resp))):
             result = await ontopo.check_availability("58551219", "20260421", "2000", 2)
 
         assert result["available"] is True
         assert len(result["slots"]) == 2
         assert result["slots"][0]["time"] == "20:00"
-        assert result["booking_url"] == "https://ontopo.com/he/il/page/58551219?date=20260421&time=2000&size=2"
 
     @pytest.mark.asyncio
-    async def test_check_availability_returns_not_available_when_no_seat_slots(self):
-        """Returns available=False when all slots are disabled/standby."""
+    async def test_check_availability_returns_not_available(self):
         from services import ontopo
-        ontopo._token_cache["token"] = "cached-token"
-        ontopo._token_cache["expires_at"] = 9999999999
+        ontopo._token_cache.update({"token": "t", "expires_at": 9_999_999_999})
 
-        api_response = {
-            "areas": [
-                {
-                    "name": "פנים",
-                    "options": [
-                        {"method": "disabled", "time": "2000"},
-                        {"method": "standby", "time": "2030"},
-                    ],
-                }
-            ],
+        api_resp = {
+            "areas": [{"name": "פנים", "options": [
+                {"method": "disabled", "time": "2000"},
+                {"method": "standby", "time": "2030"},
+            ]}],
             "recommended": [],
             "dates": ["202604221900"],
         }
-
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = api_response
-
-        with patch("httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(return_value=mock_resp)
-            mock_cls.return_value = mock_client
-
+        with patch("httpx.AsyncClient", return_value=_mock_httpx_client(post=_json_resp(api_resp))):
             result = await ontopo.check_availability("58551219", "20260421", "2000", 2)
 
         assert result["available"] is False
@@ -128,18 +117,12 @@ class TestOntopoService:
 
     @pytest.mark.asyncio
     async def test_check_availability_handles_api_error(self):
-        """Returns error dict on API failure."""
         from services import ontopo
-        ontopo._token_cache["token"] = "cached-token"
-        ontopo._token_cache["expires_at"] = 9999999999
+        ontopo._token_cache.update({"token": "t", "expires_at": 9_999_999_999})
 
-        with patch("httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(side_effect=Exception("timeout"))
-            mock_cls.return_value = mock_client
-
+        err_client = _mock_httpx_client()
+        err_client.post = AsyncMock(side_effect=Exception("timeout"))
+        with patch("httpx.AsyncClient", return_value=err_client):
             result = await ontopo.check_availability("999", "20260421", "2000", 2)
 
         assert result["available"] is False
@@ -147,71 +130,36 @@ class TestOntopoService:
 
 
 # ---------------------------------------------------------------------------
-# Tabit service tests
+# Tabit service
 # ---------------------------------------------------------------------------
 
 class TestTabitService:
-    """Unit tests for api/services/tabit.py"""
-
     @pytest.mark.asyncio
-    async def test_check_availability_returns_true_when_reservation_created(self):
-        """Returns available=True when temp reservation ID returned."""
+    async def test_check_availability_returns_true(self):
         from services import tabit
-
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"id": "tmp-res-abc123", "alternative_results": []}
-
-        mock_del_resp = MagicMock()
-
-        with patch("httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(return_value=mock_resp)
-            mock_client.delete = AsyncMock(return_value=mock_del_resp)
-            mock_cls.return_value = mock_client
-
+        resp = _json_resp({"id": "tmp-res-abc123", "alternative_results": []})
+        with patch("httpx.AsyncClient", return_value=_mock_httpx_client(post=resp, delete=MagicMock())):
             result = await tabit.check_availability("org-123", "2026-04-21", "20:00", 2)
 
         assert result["available"] is True
-        assert len(result["slots"]) == 1
         assert result["slots"][0]["time"] == "20:00"
 
     @pytest.mark.asyncio
-    async def test_check_availability_returns_false_when_no_reservation_id(self):
-        """Returns available=False when no reservation ID (slot taken)."""
+    async def test_check_availability_returns_false(self):
         from services import tabit
-
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {
-            "alternative_results": [{"time": "20:30"}, {"time": "21:00"}]
-        }
-
-        with patch("httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(return_value=mock_resp)
-            mock_cls.return_value = mock_client
-
+        resp = _json_resp({"alternative_results": [{"time": "20:30"}, {"time": "21:00"}]})
+        with patch("httpx.AsyncClient", return_value=_mock_httpx_client(post=resp)):
             result = await tabit.check_availability("org-123", "2026-04-21", "20:00", 2)
 
         assert result["available"] is False
-        assert result["slots"] == []
         assert len(result["alternative_slots"]) == 2
 
     @pytest.mark.asyncio
     async def test_check_availability_handles_exception(self):
-        """Returns error dict on network failure."""
         from services import tabit
-
-        with patch("httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.post = AsyncMock(side_effect=Exception("connection refused"))
-            mock_cls.return_value = mock_client
-
+        err_client = _mock_httpx_client()
+        err_client.post = AsyncMock(side_effect=Exception("connection refused"))
+        with patch("httpx.AsyncClient", return_value=err_client):
             result = await tabit.check_availability("org-456", "2026-04-21", "20:00", 2)
 
         assert result["available"] is False
@@ -219,261 +167,151 @@ class TestTabitService:
 
 
 # ---------------------------------------------------------------------------
-# Chat router tool handler tests
+# Chat router tool handlers
 # ---------------------------------------------------------------------------
 
-def _import_chat():
-    """Import chat module directly, bypassing routers/__init__.py to avoid jose dep."""
-    import importlib.util, pathlib
-    spec = importlib.util.spec_from_file_location(
-        "chat",
-        pathlib.Path(PROJECT_ROOT) / "api" / "routers" / "chat.py",
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
 class TestChatToolHandlers:
-    """Unit tests for tool handler functions in routers/chat.py"""
+    @pytest.fixture(autouse=True)
+    def chat(self):
+        self.chat = _import_chat()
 
     @pytest.mark.asyncio
     async def test_search_restaurants_returns_json(self):
-        """_tool_search_restaurants returns valid JSON with restaurant list."""
-        chat = _import_chat()
-        _tool_search_restaurants = chat._tool_search_restaurants
+        data = {"restaurants": [{"id": "1", "name_hebrew": "רומנו", "city": "תל אביב",
+                                  "cuisine_type": "איטלקי", "google_rating": 4.5,
+                                  "description": "מסעדה", "ontopo_slug": "58551219",
+                                  "tabit_org_id": None, "address": "הרצל 1"}]}
+        with patch("httpx.AsyncClient", return_value=_mock_httpx_client(get=_json_resp(data))):
+            result = await self.chat._tool_search_restaurants(city="תל אביב", cuisine="איטלקי")
 
-        mock_data = {
-            "restaurants": [
-                {
-                    "id": "1",
-                    "name_hebrew": "רומנו",
-                    "name_english": "Romano",
-                    "city": "תל אביב",
-                    "cuisine_type": "איטלקי",
-                    "google_rating": 4.5,
-                    "description": "מסעדה איטלקית",
-                    "ontopo_slug": "58551219",
-                    "tabit_org_id": None,
-                    "address": "רחוב הרצל 1",
-                }
-            ]
-        }
-
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = mock_data
-
-        with patch("httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=mock_resp)
-            mock_cls.return_value = mock_client
-
-            result = await _tool_search_restaurants(city="תל אביב", cuisine="איטלקי")
-
-        data = json.loads(result)
-        assert isinstance(data, list)
-        assert data[0]["name_hebrew"] == "רומנו"
-        assert data[0]["ontopo_slug"] == "58551219"
+        parsed = json.loads(result)
+        assert parsed[0]["name_hebrew"] == "רומנו"
+        assert parsed[0]["ontopo_slug"] == "58551219"
 
     @pytest.mark.asyncio
     async def test_search_restaurants_handles_error(self):
-        """_tool_search_restaurants returns error JSON on failure."""
-        _tool_search_restaurants = _import_chat()._tool_search_restaurants
+        err_client = _mock_httpx_client()
+        err_client.get = AsyncMock(side_effect=Exception("API down"))
+        with patch("httpx.AsyncClient", return_value=err_client):
+            result = await self.chat._tool_search_restaurants(city="תל אביב")
 
-        with patch("httpx.AsyncClient") as mock_cls:
-            mock_client = AsyncMock()
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(side_effect=Exception("API down"))
-            mock_cls.return_value = mock_client
-
-            result = await _tool_search_restaurants(city="תל אביב")
-
-        data = json.loads(result)
-        assert "error" in data
+        assert "error" in json.loads(result)
 
     @pytest.mark.asyncio
     async def test_tool_check_ontopo_formats_date_and_time(self):
-        """_tool_check_ontopo strips dashes and colons before calling service."""
-        _tool_check_ontopo = _import_chat()._tool_check_ontopo
-
         with patch("services.ontopo.check_availability") as mock_check:
-            mock_check.return_value = {
-                "available": True,
-                "slots": [{"time": "20:00", "area": "חוץ"}],
-                "recommended": [],
-                "alternative_dates": [],
-                "booking_url": "https://ontopo.com/he/il/page/123",
-            }
-
-            result = await _tool_check_ontopo(
-                ontopo_slug="123",
-                date="2026-04-21",
-                time="20:00",
-                party_size=2,
+            mock_check.return_value = {"available": True, "slots": [{"time": "20:00", "area": "חוץ"}],
+                                        "recommended": [], "alternative_dates": [],
+                                        "booking_url": "https://ontopo.com/he/il/page/123"}
+            result = await self.chat._tool_check_ontopo(
+                ontopo_slug="123", date="2026-04-21", time="20:00", party_size=2
             )
 
-        # Check service was called with stripped formats
         mock_check.assert_called_once_with(
-            numeric_slug="123",
-            date="20260421",
-            time_str="2000",
-            party_size=2,
+            numeric_slug="123", date="20260421", time_str="2000", party_size=2
         )
-        data = json.loads(result)
-        assert data["available"] is True
+        assert json.loads(result)["available"] is True
 
     @pytest.mark.asyncio
     async def test_tool_check_tabit_passes_correct_params(self):
-        """_tool_check_tabit passes org_id and datetime correctly."""
-        _tool_check_tabit = _import_chat()._tool_check_tabit
-
         with patch("services.tabit.check_availability") as mock_check:
-            mock_check.return_value = {
-                "available": False,
-                "slots": [],
-                "alternative_slots": [{"time": "21:00"}],
-            }
-
-            result = await _tool_check_tabit(
-                tabit_org_id="org-abc",
-                date="2026-04-21",
-                time="20:00",
-                party_size=4,
+            mock_check.return_value = {"available": False, "slots": [], "alternative_slots": [{"time": "21:00"}]}
+            result = await self.chat._tool_check_tabit(
+                tabit_org_id="org-abc", date="2026-04-21", time="20:00", party_size=4
             )
 
         mock_check.assert_called_once_with(
-            org_id="org-abc",
-            date="2026-04-21",
-            time_str="20:00",
-            party_size=4,
+            org_id="org-abc", date="2026-04-21", time_str="20:00", party_size=4
         )
-        data = json.loads(result)
-        assert data["available"] is False
-        assert len(data["alternative_slots"]) == 1
+        assert json.loads(result)["available"] is False
 
 
 # ---------------------------------------------------------------------------
-# Chat endpoint integration tests
+# Chat endpoint integration
 # ---------------------------------------------------------------------------
+
+def _make_app():
+    from fastapi import FastAPI
+    chat_module = _import_chat()
+    app = FastAPI()
+    app.include_router(chat_module.router)
+    return app, chat_module
+
+
+def _text_response(text):
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    resp = MagicMock()
+    resp.stop_reason = "end_turn"
+    resp.content = [block]
+    return resp
+
+
+def _tool_response(name, tool_id, input_data):
+    block = MagicMock()
+    block.type = "tool_use"
+    block.name = name
+    block.id = tool_id
+    block.input = input_data
+    resp = MagicMock()
+    resp.stop_reason = "tool_use"
+    resp.content = [block]
+    return resp
+
 
 class TestChatEndpoint:
-    """Integration tests for POST /api/chat/message"""
-
     @pytest.mark.asyncio
     async def test_endpoint_returns_reply_on_end_turn(self):
-        """Endpoint returns reply text when Claude stops with end_turn."""
         from fastapi.testclient import TestClient
-        from fastapi import FastAPI
-        chat_module = _import_chat()
+        app, _ = _make_app()
 
-        # Minimal FastAPI app with just the chat router
-        test_app = FastAPI()
-        test_app.include_router(chat_module.router)
-
-        # Build a mock Claude response with end_turn
-        mock_content_block = MagicMock()
-        mock_content_block.type = "text"
-        mock_content_block.text = "הנה שלוש מסעדות מומלצות..."
-
-        mock_response = MagicMock()
-        mock_response.stop_reason = "end_turn"
-        mock_response.content = [mock_content_block]
-
-        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test-key"}):
-            with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-                mock_client = AsyncMock()
-                mock_client.messages.create = AsyncMock(return_value=mock_response)
-                mock_anthropic_cls.return_value = mock_client
-
-                with TestClient(test_app) as client:
-                    resp = client.post(
-                        "/api/chat/message",
-                        json={
-                            "message": "מחפש מסעדה לדייט בתל אביב",
-                            "session_id": "test-session",
-                            "history": [],
-                        },
-                    )
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            with patch("anthropic.AsyncAnthropic") as mock_cls:
+                mock_cls.return_value.messages.create = AsyncMock(
+                    return_value=_text_response("הנה שלוש מסעדות מומלצות...")
+                )
+                with TestClient(app) as client:
+                    resp = client.post("/api/chat/message", json={
+                        "message": "מחפש מסעדה לדייט בתל אביב",
+                        "session_id": "test-session",
+                        "history": [],
+                    })
 
         assert resp.status_code == 200
-        data = resp.json()
-        assert data["reply"] == "הנה שלוש מסעדות מומלצות..."
-        assert data["session_id"] == "test-session"
+        assert resp.json()["reply"] == "הנה שלוש מסעדות מומלצות..."
+        assert resp.json()["session_id"] == "test-session"
 
     @pytest.mark.asyncio
     async def test_endpoint_executes_tool_and_returns_final_reply(self):
-        """Endpoint calls tool handler and loops back to get final reply."""
-        from fastapi import FastAPI
         from fastapi.testclient import TestClient
-        chat_module = _import_chat()
+        app, chat_module = _make_app()
 
-        test_app = FastAPI()
-        test_app.include_router(chat_module.router)
-
-        # First response: tool_use
-        tool_block = MagicMock()
-        tool_block.type = "tool_use"
-        tool_block.name = "search_restaurants"
-        tool_block.id = "tool-1"
-        tool_block.input = {"city": "תל אביב", "cuisine": "איטלקי"}
-
-        response_turn1 = MagicMock()
-        response_turn1.stop_reason = "tool_use"
-        response_turn1.content = [tool_block]
-
-        # Second response: end_turn
-        text_block = MagicMock()
-        text_block.type = "text"
-        text_block.text = "מצאתי מסעדות מעולות!"
-
-        response_turn2 = MagicMock()
-        response_turn2.stop_reason = "end_turn"
-        response_turn2.content = [text_block]
-
-        # Mock tool handler
-        mock_tool_result = json.dumps([{"name_hebrew": "טסטו", "city": "תל אביב"}])
-
-        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test-key"}):
-            with patch("anthropic.AsyncAnthropic") as mock_anthropic_cls:
-                mock_client = AsyncMock()
-                mock_client.messages.create = AsyncMock(
-                    side_effect=[response_turn1, response_turn2]
-                )
-                mock_anthropic_cls.return_value = mock_client
-
-                with patch.dict(
-                    chat_module.TOOL_HANDLERS,
-                    {"search_restaurants": AsyncMock(return_value=mock_tool_result)},
-                ):
-                    with TestClient(test_app) as client:
-                        resp = client.post(
-                            "/api/chat/message",
-                            json={"message": "מסעדה איטלקית בתל אביב", "history": []},
-                        )
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            with patch("anthropic.AsyncAnthropic") as mock_cls:
+                mock_cls.return_value.messages.create = AsyncMock(side_effect=[
+                    _tool_response("search_restaurants", "tool-1", {"city": "תל אביב", "cuisine": "איטלקי"}),
+                    _text_response("מצאתי מסעדות מעולות!"),
+                ])
+                mock_result = json.dumps([{"name_hebrew": "טסטו", "city": "תל אביב"}])
+                with patch.dict(chat_module.TOOL_HANDLERS,
+                                {"search_restaurants": AsyncMock(return_value=mock_result)}):
+                    with TestClient(app) as client:
+                        resp = client.post("/api/chat/message",
+                                           json={"message": "מסעדה איטלקית בתל אביב", "history": []})
 
         assert resp.status_code == 200
         assert resp.json()["reply"] == "מצאתי מסעדות מעולות!"
-        assert mock_client.messages.create.call_count == 2
+        assert mock_cls.return_value.messages.create.call_count == 2
 
     def test_endpoint_returns_500_without_api_key(self):
-        """Returns 500 when ANTHROPIC_API_KEY is missing."""
-        from fastapi import FastAPI
         from fastapi.testclient import TestClient
-        chat_module = _import_chat()
+        app, _ = _make_app()
 
-        test_app = FastAPI()
-        test_app.include_router(chat_module.router)
-
-        env_without_key = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
-        with patch.dict(os.environ, env_without_key, clear=True):
-            with TestClient(test_app) as client:
-                resp = client.post(
-                    "/api/chat/message",
-                    json={"message": "שלום", "history": []},
-                )
+        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with TestClient(app) as client:
+                resp = client.post("/api/chat/message", json={"message": "שלום", "history": []})
 
         assert resp.status_code == 500
         assert "ANTHROPIC_API_KEY" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

• Adds `POST /api/chat/message` — a Claude Opus 4.6 powered agent that answers Hebrew natural language restaurant queries
• Agent searches the where2eat DB, checks live seat availability on Ontopo and Tabit, and returns ranked recommendations with booking links
• No reservations are created — Ontopo is fully read-only, Tabit temp reservations auto-expire in 5 min

## New files

• `api/services/ontopo.py` — async Ontopo client with JWT token caching
• `api/services/tabit.py` — async Tabit client (temp reservation pattern)
• `api/routers/chat.py` — FastAPI endpoint, 3 tools, 6-iteration agentic loop, Hebrew system prompt
• `tests/test_chat_agent.py` — 14 unit + integration tests (all green ✅)

## Changes to existing files

• `api/routers/__init__.py` — registered `chat_router`
• `api/main.py` — `app.include_router(chat_router)`
• `api/requirements.txt` — added `anthropic>=0.40.0`

## Test plan

- [x] All 14 unit tests pass locally
- [ ] Deploy to Railway staging and hit `/api/chat/message` with a live query
- [ ] Verify ANTHROPIC_API_KEY is set in Railway env
- [ ] Test: "מחפש מסעדה לדייט בתל אביב ביום חמישי" → should return 3 restaurants with availability
- [ ] Test: missing API key → 500 with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)