### PR TITLE
feat: add status field to episode_mentions (fix closures in גם הוזכרו)

### DIFF
--- a/api/routers/episodes.py
+++ b/api/routers/episodes.py
@@ -299,6 +299,7 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
                 'name_english': r.get('name_english'),
                 'verdict': verdict,
                 'mention_level': r.get('sub_tag') or r.get('mention_level'),
+                'status': r.get('status'),
                 'timestamp_seconds': timestamp.get('seconds'),
                 'timestamp_display': timestamp.get('display'),
                 'speaker': r.get('speaker'),

--- a/src/database.py
+++ b/src/database.py
@@ -134,6 +134,7 @@ class Database:
                     name_english TEXT,
                     verdict TEXT NOT NULL,
                     mention_level TEXT,
+                    status TEXT,
                     timestamp_seconds REAL,
                     timestamp_display TEXT,
                     speaker TEXT,
@@ -513,6 +514,12 @@ class Database:
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_episode_mentions_video_id ON episode_mentions(video_id)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_episode_mentions_restaurant_id ON episode_mentions(restaurant_id)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_episode_mentions_verdict ON episode_mentions(verdict)')
+
+            # Migrate existing episode_mentions tables that lack the status column
+            try:
+                cursor.execute('ALTER TABLE episode_mentions ADD COLUMN status TEXT')
+            except Exception:
+                pass  # Column already exists
 
     # ==================== Episode Operations ====================
 
@@ -2094,15 +2101,16 @@ class Database:
             cursor.execute('''
                 INSERT INTO episode_mentions (
                     id, episode_id, restaurant_id, video_id, name_hebrew, name_english,
-                    verdict, mention_level, timestamp_seconds, timestamp_display,
+                    verdict, mention_level, status, timestamp_seconds, timestamp_display,
                     speaker, host_quotes, host_comments, dishes_mentioned,
                     mention_context, skip_reason, city, cuisine_type, host_opinion,
                     google_place_id, latitude, longitude
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     restaurant_id = COALESCE(excluded.restaurant_id, episode_mentions.restaurant_id),
                     verdict = excluded.verdict,
                     mention_level = excluded.mention_level,
+                    status = COALESCE(excluded.status, episode_mentions.status),
                     host_quotes = COALESCE(excluded.host_quotes, episode_mentions.host_quotes),
                     host_comments = COALESCE(excluded.host_comments, episode_mentions.host_comments),
                     dishes_mentioned = COALESCE(excluded.dishes_mentioned, episode_mentions.dishes_mentioned)
@@ -2115,6 +2123,7 @@ class Database:
                 data.get('name_english'),
                 data['verdict'],
                 data.get('mention_level'),
+                data.get('status'),
                 data.get('timestamp_seconds'),
                 data.get('timestamp_display'),
                 data.get('speaker'),


### PR DESCRIPTION
## Problem

reference_only mentions (shown in \"גם הוזכרו\" on episode pages) had no \`status\` field. When a restaurant was mentioned as closed (e.g. המקדש in episode 153), the UI had no way to show that.

## Changes

• *\`src/database.py\`* — added \`status TEXT\` column to \`episode_mentions\` schema + auto-migration via \`ALTER TABLE ADD COLUMN\` (no-op if column already exists — safe on live DB)
• *\`api/routers/episodes.py\`* — seed endpoint now passes \`r.get('status')\` when saving mentions; ON CONFLICT upsert preserves existing status

## After merging

Re-seed episode 153 (x6dASq4vL4w) so המקדש gets \`status=נסגר\`. Script:
\`\`\`bash
curl -X POST https://where2eat-production.up.railway.app/api/episodes/seed \
  -H 'Content-Type: application/json' \
  -d @agentic_extractor/episode_x6dASq4vL4w_extraction.json
\`\`\`

## Test plan

- [ ] Deploy to Railway — migration runs on startup, no downtime
- [ ] Re-seed episode 153
- [ ] Verify המקדש appears with \`status: נסגר\` in \`GET /api/episodes/x6dASq4vL4w\`
- [ ] Confirm existing mentions unaffected (status=null where not set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)