### PR TITLE
fix: deterministic UUID for episode_mentions (prevents re-seed duplicates)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -2094,7 +2094,11 @@ class Database:
         Returns:
             Mention ID
         """
-        mention_id = data.get('id', str(uuid.uuid4()))
+        # Use deterministic UUID so re-seeding updates existing records instead of inserting duplicates
+        mention_id = data.get('id') or str(uuid.uuid5(
+            uuid.NAMESPACE_DNS,
+            f"{data['video_id']}:{data['name_hebrew']}"
+        ))
 
         with self.get_connection() as conn:
             cursor = conn.cursor()


### PR DESCRIPTION
## Problem

`save_episode_mention()` called `str(uuid.uuid4())` on every invocation.
Since the UUID was always new, `ON CONFLICT(id) DO UPDATE` never triggered.
Re-seeding an episode (e.g. after a bug fix) created duplicate rows instead of updating existing ones.

Episode 153 currently has ~4 copies of each mention because of this.

## Fix

Use `uuid5(NAMESPACE_DNS, "{video_id}:{name_hebrew}")` — a deterministic UUID derived from the natural key.
Same mention always gets the same ID → re-seeds safely upsert.

The `data.get('id')` escape hatch is preserved so callers can still supply an explicit ID if needed.

## After merging

1. Deploy to Railway
2. Clean up duplicate episode_mentions for episode 153 (delete rows where id ≠ deterministic UUID)
3. Re-seed episode 153 once → המקדש gets `status: נסגר`

## Test plan
- [ ] Re-seed same episode twice → row count stays the same
- [ ] Existing status/fields preserved on re-seed (COALESCE logic)