### PR TITLE
fix: clear episode_mentions before re-seeding (idempotent seed)

### DIFF
--- a/api/routers/episodes.py
+++ b/api/routers/episodes.py
@@ -210,6 +210,13 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
             else:
                 raise HTTPException(status_code=500, detail="Could not create or find episode")
 
+    # Clear existing mentions for this episode before inserting fresh ones
+    # This ensures re-seeding is idempotent and removes any old duplicate records
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM episode_mentions WHERE video_id = ?", (video_id,))
+        conn.commit()
+
     # Save mentions
     mentions_added = 0
     restaurants = extraction.get('restaurants', [])

--- a/src/database.py
+++ b/src/database.py
@@ -2094,7 +2094,11 @@ class Database:
         Returns:
             Mention ID
         """
-        mention_id = data.get('id', str(uuid.uuid4()))
+        # Use deterministic UUID so re-seeding updates existing records instead of inserting duplicates
+        mention_id = data.get('id') or str(uuid.uuid5(
+            uuid.NAMESPACE_DNS,
+            f"{data['video_id']}:{data['name_hebrew']}"
+        ))
 
         with self.get_connection() as conn:
             cursor = conn.cursor()


### PR DESCRIPTION
## Problem

Re-seeding an episode appended new duplicate rows because random UUIDs ensured ON CONFLICT never triggered. Episode 153 accumulated ~4 copies of each mention record.

## Fix

The seed endpoint now DELETEs all existing `episode_mentions` for the episode before inserting fresh rows. Re-seeding is fully idempotent:
- Old duplicates get wiped on the next seed
- Fresh rows are inserted with the deterministic UUIDs from PR #256

## After merging

Re-seed episode 153 once → all duplicates gone, המקדש gets `status: נסגר`