### PR TITLE
fix: deterministic UUID for episode_mentions — eliminates duplicate records on re-seed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,6 @@ RUN pip install --no-cache-dir \
 COPY src ./src
 COPY api ./api
 
-# Copy restaurant backup data to a path OUTSIDE the /app/data volume mount
-# so it's always available for seeding even when a Railway volume is mounted
-COPY data/restaurants_backup ./seed/restaurants_backup
-
-# Also copy to the default data path (works when no volume is mounted)
-COPY data/restaurants_backup ./data/restaurants_backup
-
 # Set PYTHONPATH to include src directory for imports
 ENV PYTHONPATH="/app/src:${PYTHONPATH}"
 

--- a/api/routers/episodes.py
+++ b/api/routers/episodes.py
@@ -210,6 +210,13 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
             else:
                 raise HTTPException(status_code=500, detail="Could not create or find episode")
 
+    # Clear existing mentions for this episode before inserting fresh ones
+    # This ensures re-seeding is idempotent and removes any old duplicate records
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM episode_mentions WHERE video_id = ?", (video_id,))
+        conn.commit()
+
     # Save mentions
     mentions_added = 0
     restaurants = extraction.get('restaurants', [])

--- a/api/routers/episodes.py
+++ b/api/routers/episodes.py
@@ -149,6 +149,24 @@ async def get_episode_detail(video_id: str):
 
 
 @router.delete(
+    "/{video_id}/mentions",
+    summary="Delete all mentions for a specific episode",
+    description="Clears episode_mentions rows for the given video_id. Use before re-seeding to eliminate duplicates.",
+)
+async def delete_episode_mentions(video_id: str):
+    """Delete all episode_mentions for a specific video_id."""
+    db = _get_sqlite_db()
+    if not db:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM episode_mentions WHERE video_id = ?", (video_id,))
+        deleted = cursor.rowcount
+        conn.commit()
+    return {"status": "ok", "video_id": video_id, "deleted": deleted}
+
+
+@router.delete(
     "/reset",
     summary="Reset all episode data",
     description="Deletes all episodes, mentions, and restaurants. Use with caution.",

--- a/api/routers/episodes.py
+++ b/api/routers/episodes.py
@@ -206,9 +206,10 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
 
     episode_id = ep.get('episode_id') or str(uuid.uuid4())
 
-    # Create episode
+    # Create episode — use the RETURNED id (create_episode handles ON CONFLICT and
+    # returns the existing id when video_id already exists, so we must not ignore it)
     try:
-        db.create_episode(
+        episode_id = db.create_episode(
             video_id=video_id,
             video_url=ep.get('video_url', f'https://www.youtube.com/watch?v={video_id}'),
             title=ep.get('title', ''),
@@ -218,7 +219,7 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
             id=episode_id,
         )
     except Exception:
-        # Episode exists — look up its ID
+        # Fallback: look up existing episode if create raised unexpectedly
         with db.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("SELECT id FROM episodes WHERE video_id = ?", (video_id,))

--- a/api/routers/health.py
+++ b/api/routers/health.py
@@ -31,6 +31,7 @@ async def health_check():
     response = {
         "status": "OK",
         "timestamp": datetime.now().isoformat(),
+        "version": "2026-05-02-b",
     }
 
     try:

--- a/src/database.py
+++ b/src/database.py
@@ -2094,7 +2094,11 @@ class Database:
         Returns:
             Mention ID
         """
-        mention_id = data.get('id', str(uuid.uuid4()))
+        # Use deterministic UUID so re-seeding updates existing records instead of inserting duplicates
+        mention_id = data.get('id') or str(uuid.uuid5(
+            uuid.NAMESPACE_DNS,
+            f"{data['video_id']}:{data['name_hebrew']}"
+        ))
 
         with self.get_connection() as conn:
             cursor = conn.cursor()


### PR DESCRIPTION
## Problem

Every call to `save_episode_mention` generated a new random UUID via `str(uuid.uuid4())`. Since `ON CONFLICT(id)` uses the UUID as the key, re-seeding an episode always inserted new rows instead of updating existing ones → duplicates accumulated.

## Changes

- **Deterministic UUID**: `save_episode_mention` now derives the ID from `uuid5(NAMESPACE_DNS, "{video_id}:{name_hebrew}")` — same input always produces the same UUID, so `ON CONFLICT(id) DO UPDATE` actually fires on re-seed.
- **Clear-before-seed fallback**: Also added a `DELETE /api/episodes/{video_id}/mentions` endpoint used before re-seeding to clean any existing duplicates.
- **Seed uses returned episode_id**: Fixed seed endpoint to use the `episode_id` returned from `create_episode` (not re-read from request).
- **Dockerfile fix**: Removed reference to `data/restaurants_backup` (gitignored, was breaking builds).

## Result

Episode 153 had ~4 duplicate sets of mentions (from multiple re-seed attempts). After deploy, run seed once → clean single record per restaurant.