### PR TITLE
feat: show closed badge on episode mentions with status=נסגר

### DIFF
--- a/web/src/app/episode/[videoId]/page.tsx
+++ b/web/src/app/episode/[videoId]/page.tsx
@@ -71,6 +71,11 @@ function ExpandableRestaurantItem({
             <span className="font-bold text-sm text-[var(--color-ink)] truncate">
               {mention.name_hebrew}
             </span>
+            {mention.status === 'נסגר' && (
+              <span className="shrink-0 text-xs font-semibold bg-red-100 text-red-600 px-1.5 py-0.5 rounded-full">
+                נסגר
+              </span>
+            )}
             {mention.mention_level && (
               <MentionLevelBadge mentionLevel={mention.mention_level} />
             )}

--- a/web/src/types/restaurant.ts
+++ b/web/src/types/restaurant.ts
@@ -162,6 +162,7 @@ export interface EpisodeMention {
   website?: string;
   phone?: string;
   special_features?: string[];
+  status?: string | null;
   restaurant?: Restaurant;
 }
 


### PR DESCRIPTION
## Summary
• Adds `status` field to `EpisodeMention` TypeScript interface
• Shows a red "נסגר" pill badge next to the restaurant name in `ExpandableRestaurantItem` when `mention.status === 'נסגר'`
• Completes the episode_mentions status feature — backend already stores status, now the frontend displays it

## Test plan
- [ ] Open episode 153 page on where2eat.rest
- [ ] Expand "גם הוזכרו" section
- [ ] Verify המקדש shows a red "נסגר" badge next to its name
- [ ] Verify other restaurants (without status) show no badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)