### PR TITLE
Stop silent mention drops in /api/episodes/seed

### DIFF
--- a/api/routers/episodes.py
+++ b/api/routers/episodes.py
@@ -3,6 +3,7 @@
 Serves episode data with mention-level grouping (נטעם/הוזכר/reference_only).
 """
 
+import logging
 import os
 import json
 import uuid
@@ -10,6 +11,8 @@ from pathlib import Path
 from typing import Optional, Dict, Any, List
 
 from fastapi import APIRouter, HTTPException, Query, Body
+
+logger = logging.getLogger(__name__)
 
 from models.episode import (
     EpisodeMention,
@@ -238,6 +241,7 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
 
     # Save mentions
     mentions_added = 0
+    failed_mentions: List[Dict[str, str]] = []
     restaurants = extraction.get('restaurants', [])
     for r in restaurants:
         verdict = r.get('verdict', '')
@@ -252,14 +256,23 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
         # Ignore production_db.id — always look up fresh to avoid stale references
         restaurant_id = None
 
-        # Find or create the restaurant (for both add_to_page and reference_only)
+        # Find or create the restaurant (for both add_to_page and reference_only).
+        # Lookup excludes is_hidden rows: when duplicates exist (same place_id, one
+        # visible + one hidden orphan), the hidden one would otherwise win at random.
         with db.get_connection() as conn:
             cursor = conn.cursor()
             if gp.get('place_id'):
-                cursor.execute("SELECT id FROM restaurants WHERE google_place_id = ?", (gp['place_id'],))
+                cursor.execute(
+                    "SELECT id FROM restaurants WHERE google_place_id = ? "
+                    "AND (is_hidden = 0 OR is_hidden IS NULL)",
+                    (gp['place_id'],),
+                )
             else:
-                cursor.execute("SELECT id FROM restaurants WHERE name_hebrew = ? AND video_id = ?",
-                               (r.get('name_hebrew', ''), video_id))
+                cursor.execute(
+                    "SELECT id FROM restaurants WHERE name_hebrew = ? AND video_id = ? "
+                    "AND (is_hidden = 0 OR is_hidden IS NULL)",
+                    (r.get('name_hebrew', ''), video_id),
+                )
             row = cursor.fetchone()
             if row:
                 restaurant_id = row['id']
@@ -314,7 +327,16 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
                     is_hidden=is_hidden,
                 )
             except Exception as e:
-                print(f"[SEED] Failed to create restaurant {r.get('name_hebrew', '?')}: {e}")
+                logger.exception(
+                    "[SEED] Failed to create restaurant %s for video %s",
+                    r.get('name_hebrew', '?'),
+                    video_id,
+                )
+                failed_mentions.append({
+                    'name_hebrew': r.get('name_hebrew', '?'),
+                    'stage': 'create_restaurant',
+                    'error': f'{type(e).__name__}: {e}',
+                })
 
         try:
             db.save_episode_mention({
@@ -343,7 +365,20 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
             })
             mentions_added += 1
         except Exception as e:
-            print(f"[SEED] Failed to save mention {r.get('name_hebrew', '?')}: {e}")
+            logger.exception(
+                "[SEED] Failed to save mention %s for video %s (restaurant_id=%s, place_id=%s)",
+                r.get('name_hebrew', '?'),
+                video_id,
+                restaurant_id,
+                gp.get('place_id'),
+            )
+            failed_mentions.append({
+                'name_hebrew': r.get('name_hebrew', '?'),
+                'stage': 'save_episode_mention',
+                'restaurant_id': restaurant_id,
+                'google_place_id': gp.get('place_id'),
+                'error': f'{type(e).__name__}: {e}',
+            })
             continue
 
     # Backfill mention_level on restaurants
@@ -363,4 +398,12 @@ async def seed_extraction(extraction: Dict[str, Any] = Body(...)):
         ''')
         conn.commit()
 
-    return {"status": "ok", "episode_id": episode_id, "mentions_added": mentions_added}
+    response: Dict[str, Any] = {
+        "status": "ok",
+        "episode_id": episode_id,
+        "mentions_added": mentions_added,
+    }
+    if failed_mentions:
+        response["status"] = "partial"
+        response["failed_mentions"] = failed_mentions
+    return response

--- a/src/database.py
+++ b/src/database.py
@@ -483,6 +483,19 @@ class Database:
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_restaurants_cuisine ON restaurants(cuisine_type)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_restaurants_episode ON restaurants(episode_id)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_restaurants_published_at ON restaurants(published_at)')
+            cursor.execute('CREATE INDEX IF NOT EXISTS idx_restaurants_google_place_id ON restaurants(google_place_id)')
+
+            # Prevent visible duplicates with the same place_id. Wrapped because the
+            # index creation fails if duplicates already exist; that's the data-cleanup
+            # signal — fix the duplicates first, then this guard kicks in.
+            try:
+                cursor.execute(
+                    'CREATE UNIQUE INDEX IF NOT EXISTS idx_restaurants_visible_place_id '
+                    'ON restaurants(google_place_id) '
+                    'WHERE google_place_id IS NOT NULL AND (is_hidden = 0 OR is_hidden IS NULL)'
+                )
+            except sqlite3.IntegrityError:
+                pass  # Duplicates exist — keep the index off until they're cleaned up
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_episodes_video_id ON episodes(video_id)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_admin_users_email ON admin_users(email)')


### PR DESCRIPTION
## Summary

Episode 154 uploaded with 13/14 mentions and the API returned `mentions_added: 13` with no failure indication. Investigation traced this to three intertwined issues:

1. **Lookup didn't filter `is_hidden`.** The seed endpoint's `SELECT id FROM restaurants WHERE google_place_id = ?` could return a hidden orphan when duplicates exist with the same place_id. In production, two rows shared `ChIJ9Z_EX1VLHRURzOL152hIpOs`: a visible `ad2c6588…` and a hidden `74fdc99a…`. Whichever SQLite picked first determined `restaurant_id` for the mention — non-deterministic.
2. **Errors were swallowed silently.** `save_episode_mention` failures were caught with `print(); continue` — the actual exception never landed in Railway logs, and the API response showed `mentions_added: 13` indistinguishable from a clean run.
3. **Visible duplicates were possible.** No constraint prevented two visible rows from sharing a `google_place_id`.

## Changes

- `api/routers/episodes.py:259-275` — both lookup branches now filter `AND (is_hidden = 0 OR is_hidden IS NULL)`.
- `api/routers/episodes.py:329, 367` — `print()` → `logger.exception()`. Failed mentions accumulate in `failed_mentions` and are returned in the response (status flips to `"partial"`). Future similar bugs surface immediately instead of taking hours to diagnose.
- `src/database.py:486, 488-498` — adds a non-unique index on `google_place_id` plus a partial unique index for visible rows. Pre-existing duplicates don't break startup; the unique index simply isn't created until they're cleaned up.

## Test plan

- [x] `pytest tests/test_database.py` — 38 passed
- [x] `pytest tests/test_path_resolution.py` — 12 passed
- [x] Smoke-tested schema migration with two visible duplicates → init OK, both rows preserved, unique index deferred
- [x] Smoke-tested seed lookup with one visible + one hidden duplicate → seed picks the visible row
- [x] Smoke-tested `INSERT` of a second visible row with same `place_id` → blocked by partial unique index (clean state)
- [ ] After merge: re-deploy to Railway, verify `/api/episodes/seed` for ep 154 returns `mentions_added: 14` with `place_id` populated on Rothschild's payload

## Related

The corrupted `ad2c6588` row that originally triggered the failure was deleted from production during the investigation. The remaining `74fdc99a…` row was unhidden and re-enriched, so episode 154 currently shows 14 mentions correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)